### PR TITLE
First-class support for embedded DSLs

### DIFF
--- a/source/binary-serialisation/decoder.ts
+++ b/source/binary-serialisation/decoder.ts
@@ -424,9 +424,67 @@ class CrochetIRDecoder extends BinaryReader {
         return new IR.ContinueWith(this.decode_meta_id());
       }
 
+      case t.DSL: {
+        return new IR.Dsl(
+          this.decode_meta_id(),
+          this.decode_type(),
+          this.array((_) => this.decode_dsl_node())
+        );
+      }
+
       default:
         throw unreachable(tag, "Operation");
     }
+  }
+
+  decode_dsl_node(): IR.DslNode {
+    const tag = this.decode_enum_tag(IR.DslNodeTag, "DSL Node");
+    switch (tag) {
+      case IR.DslNodeTag.NODE: {
+        return new IR.DslAstNode(
+          this.decode_dsl_meta(),
+          this.string(),
+          this.array((_) => this.decode_dsl_node()),
+          this.map((_) => [this.string(), this.decode_dsl_node()])
+        );
+      }
+
+      case IR.DslNodeTag.LITERAL: {
+        return new IR.DslAstLiteral(
+          this.decode_dsl_meta(),
+          this.decode_literal()
+        );
+      }
+
+      case IR.DslNodeTag.VARIABLE: {
+        return new IR.DslAstVariable(this.decode_dsl_meta(), this.string());
+      }
+
+      case IR.DslNodeTag.EXPRESSION: {
+        return new IR.DslAstExpression(
+          this.decode_dsl_meta(),
+          this.string(),
+          this.decode_basic_block()
+        );
+      }
+
+      case IR.DslNodeTag.LIST: {
+        return new IR.DslAstNodeList(
+          this.decode_dsl_meta(),
+          this.array((_) => this.decode_dsl_node())
+        );
+      }
+
+      default:
+        throw unreachable(tag, `DSL Node`);
+    }
+  }
+
+  decode_dsl_meta(): IR.DslMeta {
+    const line = this.uint32();
+    const column = this.uint32();
+
+    return { line, column };
   }
 
   decode_simulation_goal() {

--- a/source/generated/crochet-grammar.ts
+++ b/source/generated/crochet-grammar.ts
@@ -1349,10 +1349,12 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
   
   ContinueWith(pos: Meta, value: Expression): $T;
   
+  Dsl(pos: Meta, language: TypeApp, ast: DslAst[]): $T;
+  
       }
 
       export abstract class Expression extends Node {
-        abstract tag: "New" | "Invoke" | "Global" | "Variable" | "Self" | "List" | "Record" | "Search" | "MatchSearch" | "Project" | "Select" | "For" | "Block" | "Apply" | "Pipe" | "PipeInvoke" | "Interpolate" | "Condition" | "HasType" | "Force" | "Lazy" | "Hole" | "Return" | "Type" | "Lambda" | "IntrinsicEqual" | "ForeignInvoke" | "Parens" | "Lit" | "Handle" | "Perform" | "ContinueWith";
+        abstract tag: "New" | "Invoke" | "Global" | "Variable" | "Self" | "List" | "Record" | "Search" | "MatchSearch" | "Project" | "Select" | "For" | "Block" | "Apply" | "Pipe" | "PipeInvoke" | "Interpolate" | "Condition" | "HasType" | "Force" | "Lazy" | "Hole" | "Return" | "Type" | "Lambda" | "IntrinsicEqual" | "ForeignInvoke" | "Parens" | "Lit" | "Handle" | "Perform" | "ContinueWith" | "Dsl";
         abstract match<$T>(p: $p_Expression<$T>): $T;
         
   static get New() {
@@ -1512,6 +1514,11 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
 
   static get ContinueWith() {
     return $$Expression$_ContinueWith
+  }
+  
+
+  static get Dsl() {
+    return $$Expression$_Dsl
   }
   
 
@@ -2159,7 +2166,262 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
     }
   }
   
+
+
+  export class $$Expression$_Dsl extends Expression {
+    readonly tag!: "Dsl";
+
+    constructor(readonly pos: Meta, readonly language: TypeApp, readonly ast: DslAst[]) {
+      super();
+      Object.defineProperty(this, "tag", { value: "Dsl" });
+      ($assert_type<Meta>(pos, "Meta", Meta)); ($assert_type<TypeApp>(language, "TypeApp", TypeApp)); ($assert_type<DslAst[]>(ast, "DslAst[]", $is_array(DslAst)))
+    }
+
+    match<$T>(p: $p_Expression<$T>): $T {
+      return p.Dsl(this.pos, this.language, this.ast);
+    }
+
+    static has_instance(x: any) {
+      return x instanceof $$Expression$_Dsl;
+    }
+  }
+  
       
+
+
+      type $p_DslAst<$T> = {
+        
+  Node(pos: Meta, sig: DslSignature<DslAst>[], attrs: DslAttr[]): $T;
+  
+  Lit(pos: Meta, value: Literal): $T;
+  
+  Var(pos: Meta, name: Name): $T;
+  
+  List(pos: Meta, values: DslAst[]): $T;
+  
+  Dynamic(pos: Meta, value: Expression): $T;
+  
+      }
+
+      export abstract class DslAst extends Node {
+        abstract tag: "Node" | "Lit" | "Var" | "List" | "Dynamic";
+        abstract match<$T>(p: $p_DslAst<$T>): $T;
+        
+  static get Node() {
+    return $$DslAst$_Node
+  }
+  
+
+  static get Lit() {
+    return $$DslAst$_Lit
+  }
+  
+
+  static get Var() {
+    return $$DslAst$_Var
+  }
+  
+
+  static get List() {
+    return $$DslAst$_List
+  }
+  
+
+  static get Dynamic() {
+    return $$DslAst$_Dynamic
+  }
+  
+
+        static has_instance(x: any) {
+          return x instanceof DslAst;
+        }
+      }
+ 
+      
+  export class $$DslAst$_Node extends DslAst {
+    readonly tag!: "Node";
+
+    constructor(readonly pos: Meta, readonly sig: DslSignature<DslAst>[], readonly attrs: DslAttr[]) {
+      super();
+      Object.defineProperty(this, "tag", { value: "Node" });
+      ($assert_type<Meta>(pos, "Meta", Meta)); ($assert_type<DslSignature<DslAst>[]>(sig, "DslSignature<DslAst>[]", $is_array(DslSignature))); ($assert_type<DslAttr[]>(attrs, "DslAttr[]", $is_array(DslAttr)))
+    }
+
+    match<$T>(p: $p_DslAst<$T>): $T {
+      return p.Node(this.pos, this.sig, this.attrs);
+    }
+
+    static has_instance(x: any) {
+      return x instanceof $$DslAst$_Node;
+    }
+  }
+  
+
+
+  export class $$DslAst$_Lit extends DslAst {
+    readonly tag!: "Lit";
+
+    constructor(readonly pos: Meta, readonly value: Literal) {
+      super();
+      Object.defineProperty(this, "tag", { value: "Lit" });
+      ($assert_type<Meta>(pos, "Meta", Meta)); ($assert_type<Literal>(value, "Literal", Literal))
+    }
+
+    match<$T>(p: $p_DslAst<$T>): $T {
+      return p.Lit(this.pos, this.value);
+    }
+
+    static has_instance(x: any) {
+      return x instanceof $$DslAst$_Lit;
+    }
+  }
+  
+
+
+  export class $$DslAst$_Var extends DslAst {
+    readonly tag!: "Var";
+
+    constructor(readonly pos: Meta, readonly name: Name) {
+      super();
+      Object.defineProperty(this, "tag", { value: "Var" });
+      ($assert_type<Meta>(pos, "Meta", Meta)); ($assert_type<Name>(name, "Name", Name))
+    }
+
+    match<$T>(p: $p_DslAst<$T>): $T {
+      return p.Var(this.pos, this.name);
+    }
+
+    static has_instance(x: any) {
+      return x instanceof $$DslAst$_Var;
+    }
+  }
+  
+
+
+  export class $$DslAst$_List extends DslAst {
+    readonly tag!: "List";
+
+    constructor(readonly pos: Meta, readonly values: DslAst[]) {
+      super();
+      Object.defineProperty(this, "tag", { value: "List" });
+      ($assert_type<Meta>(pos, "Meta", Meta)); ($assert_type<DslAst[]>(values, "DslAst[]", $is_array(DslAst)))
+    }
+
+    match<$T>(p: $p_DslAst<$T>): $T {
+      return p.List(this.pos, this.values);
+    }
+
+    static has_instance(x: any) {
+      return x instanceof $$DslAst$_List;
+    }
+  }
+  
+
+
+  export class $$DslAst$_Dynamic extends DslAst {
+    readonly tag!: "Dynamic";
+
+    constructor(readonly pos: Meta, readonly value: Expression) {
+      super();
+      Object.defineProperty(this, "tag", { value: "Dynamic" });
+      ($assert_type<Meta>(pos, "Meta", Meta)); ($assert_type<Expression>(value, "Expression", Expression))
+    }
+
+    match<$T>(p: $p_DslAst<$T>): $T {
+      return p.Dynamic(this.pos, this.value);
+    }
+
+    static has_instance(x: any) {
+      return x instanceof $$DslAst$_Dynamic;
+    }
+  }
+  
+      
+
+
+      type $p_DslSignature<T, $T> = {
+        
+  Name(name: Name): $T;
+  
+  Child(value: T): $T;
+  
+      }
+
+      export abstract class DslSignature<T> extends Node {
+        abstract tag: "Name" | "Child";
+        abstract match<$T>(p: $p_DslSignature<T, $T>): $T;
+        
+  static get Name() {
+    return $$DslSignature$_Name
+  }
+  
+
+  static get Child() {
+    return $$DslSignature$_Child
+  }
+  
+
+        static has_instance(x: any) {
+          return x instanceof DslSignature;
+        }
+      }
+ 
+      
+  export class $$DslSignature$_Name<T> extends DslSignature<T> {
+    readonly tag!: "Name";
+
+    constructor(readonly name: Name) {
+      super();
+      Object.defineProperty(this, "tag", { value: "Name" });
+      ($assert_type<Name>(name, "Name", Name))
+    }
+
+    match<$T>(p: $p_DslSignature<T, $T>): $T {
+      return p.Name(this.name);
+    }
+
+    static has_instance(x: any) {
+      return x instanceof $$DslSignature$_Name;
+    }
+  }
+  
+
+
+  export class $$DslSignature$_Child<T> extends DslSignature<T> {
+    readonly tag!: "Child";
+
+    constructor(readonly value: T) {
+      super();
+      Object.defineProperty(this, "tag", { value: "Child" });
+      
+    }
+
+    match<$T>(p: $p_DslSignature<T, $T>): $T {
+      return p.Child(this.value);
+    }
+
+    static has_instance(x: any) {
+      return x instanceof $$DslSignature$_Child;
+    }
+  }
+  
+      
+
+
+  export class DslAttr extends Node {
+    readonly tag!: "DslAttr"
+
+    constructor(readonly pos: Meta, readonly key: Name, readonly value: DslAst) {
+      super();
+      Object.defineProperty(this, "tag", { value: "DslAttr" });
+      ($assert_type<Meta>(pos, "Meta", Meta)); ($assert_type<Name>(key, "Name", Name)); ($assert_type<DslAst>(value, "DslAst", DslAst))
+    }
+
+    static has_instance(x: any) {
+      return x instanceof DslAttr;
+    }
+  }
+  
 
 
       type $p_ForExpression<$T> = {
@@ -3889,7 +4151,7 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
       
 
   // == Grammar definition ============================================
-  export const grammar = Ohm.grammar("\r\n  Crochet {\r\n    program  = header declaration* space* end  -- alt1\n\n\nrepl  = ws declaration+ ws end  -- alt1\n | ws statements1 ws end  -- alt2\n | ws replCommand ws end  -- alt3\n\n\nreplCommand  = \":rollback\" hs+ signature<hole>  -- alt1\n | \":help\" hs+ command_ signature<parameter>  -- alt2\n | \":help\" hs+ type_ typeApp  -- alt3\n\n\ndeclarationMeta  = ws meta_doc  -- alt1\n\n\nmeta_doc  = doc  -- alt1\n |   -- alt2\n\n\ndeclaration  = relationDeclaration  -- alt1\n | doDeclaration  -- alt2\n | commandDeclaration  -- alt3\n | typeDeclaration  -- alt4\n | defineDeclaration  -- alt5\n | actionDeclaration  -- alt6\n | whenDeclaration  -- alt7\n | contextDeclaration  -- alt8\n | openDeclaration  -- alt9\n | localDeclaration  -- alt10\n | testDeclaration  -- alt11\n | effectDeclaration  -- alt12\n\n\neffectDeclaration  = declarationMeta effect_ atom with_ effectCase+ end_  -- alt1\n\n\neffectCase  = declarationMeta atom typeParams s<\";\">  -- alt1\n\n\ntypeParams  = s<\"(\"> list0<typeField, s<\",\">> s<\")\">  -- alt1\n\n\ntestDeclaration  = test_ string do_ statements end_  -- alt1\n\n\ntrailingTest  = oneTrailingTest  -- alt1\n | s<\";\">  -- alt2\n\n\noneTrailingTest  = test_ statements end_  -- alt1\n\n\nlocalDeclaration  = local_ defineDeclaration  -- alt1\n | local_ typeDeclaration  -- alt2\n\n\nopenDeclaration  = open_ namespace s<\";\">  -- alt1\n\n\nrelationDeclaration  = declarationMeta ws relation_ logicSignature<relationPart> s<\";\">  -- alt1\n\n\nrelationPart  = name s<\"*\">  -- alt1\n | name  -- alt2\n\n\ndoDeclaration  = prelude_ statements end_  -- alt1\n\n\ncommandDeclaration  = declarationMeta ws command_ signature<parameter> contractDefinition s<\"=\"> expression trailingTest  -- alt1\n | declarationMeta ws command_ signature<parameter> contractDefinition do_ statements oneTrailingTest  -- alt2\n | declarationMeta ws command_ signature<parameter> contractDefinition do_ statements end_  -- alt3\n\n\ncontractDefinition  = retContractDefinition preContractDefinition postContractDefinition  -- alt1\n\n\nretContractDefinition  = s<\"->\"> typeAppPrimary  -- alt1\n |   -- alt2\n\n\npreContractDefinition  = requires_ list1<contractCondition, s<\";\">>  -- alt1\n |   -- alt2\n\n\npostContractDefinition  = ensures_ list1<contractCondition, s<\";\">>  -- alt1\n |   -- alt2\n\n\ncontractCondition  = atom s<\"::\"> expression  -- alt1\n\n\nparameter  = name  -- alt1\n | s<\"(\"> name is_ typeApp s<\")\">  -- alt2\n | typeAppStatic  -- alt3\n\n\ntypeApp  = typeAppStatic  -- alt1\n\n\ntypeAppStatic  = s<\"#\"> typeAppPrimary  -- alt1\n | typeAppPrimary  -- alt2\n\n\ntypeAppPrimary  = typeName  -- alt1\n\n\ntypeName  = atom  -- alt1\n | nothing_  -- alt2\n | true_  -- alt3\n | false_  -- alt4\n\n\ntypeDeclaration  = declarationMeta ws type_ typeName s<\"=\"> foreign_ namespace s<\";\">  -- alt1\n | declarationMeta ws enum_ typeName s<\"=\"> nonemptyListOf<typeName, s<\",\">> s<\";\">  -- alt2\n | declarationMeta ws abstract_ basicType s<\";\">  -- alt3\n | declarationMeta ws singleton_ basicType typeInitBlock  -- alt4\n | declarationMeta ws type_ basicType typeFields s<\";\">  -- alt5\n\n\nbasicType  = atom typeDefParent  -- alt1\n\n\ntypeDefParent  = is_ typeApp  -- alt1\n |   -- alt2\n\n\ntypeInitBlock  = with_ typeInit* end_  -- alt1\n | s<\";\">  -- alt2\n\n\ntypeFields  = s<\"(\"> list1<typeField, s<\",\">> s<\")\">  -- alt1\n |   -- alt2\n\n\ntypeField  = typeFieldName is_ typeApp  -- alt1\n | typeFieldName  -- alt2\n\n\ntypeFieldName  = name  -- alt1\n | atom  -- alt2\n\n\ntypeInit  = partialLogicSignature<invokePostfix> s<\";\">  -- alt1\n | typeInitCommand  -- alt2\n\n\ntypeInitCommand  = declarationMeta ws command_ partialSignature<parameter> contractDefinition s<\"=\"> s<expression> trailingTest  -- alt1\n | declarationMeta ws command_ partialSignature<parameter> contractDefinition do_ statements oneTrailingTest  -- alt2\n | declarationMeta ws command_ partialSignature<parameter> contractDefinition do_ statements end_  -- alt3\n\n\ndefineDeclaration  = declarationMeta ws define_ atom s<\"=\"> s<atomicExpression> s<\";\">  -- alt1\n\n\nactionDeclaration  = declarationMeta ws action_ parameter atom interpolateExpression? actionPredicate actionRank do_ statements actionInit end_  -- alt1\n\n\nactionPredicate  = when_ predicate  -- alt1\n |   -- alt2\n\n\nactionRank  = rank_ s<expression>  -- alt1\n |   -- alt2\n\n\nactionInit  = with_ typeInitCommand*  -- alt1\n |   -- alt2\n\n\nwhenDeclaration  = declarationMeta ws when_ predicate do_ statements end_  -- alt1\n\n\ncontextDeclaration  = declarationMeta ws context_ atom with_ contextItem* end_  -- alt1\n\n\ncontextItem  = actionDeclaration  -- alt1\n | whenDeclaration  -- alt2\n\n\npredicate  = predicateBinary  -- alt1\n\n\npredicateBinary  = predicateAnd  -- alt1\n | predicateOr  -- alt2\n | predicateNot  -- alt3\n\n\npredicateAnd  = predicateNot s<\",\"> predicateAnd1  -- alt1\n\n\npredicateAnd1  = predicateNot s<\",\"> predicateAnd1  -- alt1\n | predicateNot  -- alt2\n\n\npredicateOr  = predicateNot s<\"|\"> predicateOr1  -- alt1\n\n\npredicateOr1  = predicateNot s<\"|\"> predicateOr1  -- alt1\n | predicateNot  -- alt2\n\n\npredicateNot  = not_ predicateConstrain  -- alt1\n | predicateConstrain  -- alt2\n\n\npredicateConstrain  = predicateLet if_ s<expression>  -- alt1\n | if_ s<expression>  -- alt2\n | predicateLet  -- alt3\n | predicateSample  -- alt4\n | predicateType  -- alt5\n | predicatePrimary  -- alt6\n\n\npredicateType  = name is_ typeApp  -- alt1\n\n\npredicateLet  = let_ name s<\"=\"> s<expression>  -- alt1\n\n\npredicateSample  = sample_ integer of_ samplingPool  -- alt1\n\n\nsamplingPool  = logicSignature<pattern>  -- alt1\n | name is_ typeApp  -- alt2\n\n\npredicatePrimary  = always_  -- alt1\n | logicSignature<pattern>  -- alt2\n | s<\"(\"> predicate s<\")\">  -- alt3\n\n\npattern  = s<\"(\"> patternComplex s<\")\">  -- alt1\n | atom  -- alt2\n | self_  -- alt3\n | literal  -- alt4\n | patternName  -- alt5\n\n\npatternComplex  = patternName is_ typeApp  -- alt1\n\n\npatternName  = s<\"_\">  -- alt1\n | name  -- alt2\n\n\nstatement  = s<letStatement>  -- alt1\n | s<factStatement>  -- alt2\n | s<forgetStatement>  -- alt3\n | s<simulateStatement>  -- alt4\n | s<assertStatement>  -- alt5\n | s<expression>  -- alt6\n\n\nblockStatement  = blockExpression  -- alt1\n\n\nletStatement  = let_ name s<\"=\"> s<expression>  -- alt1\n\n\nfactStatement  = fact_ logicSignature<primaryExpression>  -- alt1\n\n\nforgetStatement  = forget_ logicSignature<primaryExpression>  -- alt1\n\n\nsimulateStatement  = simulate_ for_ expression simulateContext until_ simulateGoal signal*  -- alt1\n\n\nsimulateContext  = in_ atom  -- alt1\n |   -- alt2\n\n\nsimulateGoal  = action_ quiescence_  -- alt1\n | event_ quiescence_  -- alt2\n | quiescence_  -- alt3\n | predicate  -- alt4\n\n\nsignal  = on_ signature<parameter> do_ statements end_  -- alt1\n\n\nassertStatement  = assert_ expression  -- alt1\n\n\nexpression  = blockExpression  -- alt1\n | s<searchExpression>  -- alt2\n | s<lazyExpression>  -- alt3\n | s<forceExpression>  -- alt4\n | s<foreignExpression>  -- alt5\n | s<continueWithExpression>  -- alt6\n | s<pipeExpression>  -- alt7\n\n\nsearchExpression  = search_ predicate  -- alt1\n\n\nlazyExpression  = lazy_ expression  -- alt1\n\n\nforceExpression  = force_ expression  -- alt1\n\n\nforeignExpression  = foreign_ namespace s<\"(\"> list0<expression, s<\",\">> s<\")\">  -- alt1\n\n\ncontinueWithExpression  = continue_ with_ pipeExpression  -- alt1\n\n\nexpressionBlock  = do_ statements end_  -- alt1\n\n\npipeExpression  = pipeExpression s<\"|>\"> invokeInfixExpression  -- alt1\n | pipeExpression s<\"|\"> partialSignature<invokePostfix>  -- alt2\n | invokeInfixExpression  -- alt3\n\n\ninvokeInfixExpression  = invokeMixfix s<\"=:=\"> invokeMixfix  -- alt1\n | invokeInfixExpression infix_symbol invokeMixfix  -- alt2\n | invokeMixfix  -- alt3\n\n\ninvokeMixfix  = castExpression signaturePair<invokePostfix>+  -- alt1\n | signaturePair<invokePostfix>+  -- alt2\n | castExpression  -- alt3\n\n\ncastExpression  = invokePrePost as castType  -- alt1\n | invokePrePost is_ typeAppPrimary  -- alt2\n | invokePrePost  -- alt3\n\n\ncastType  = typeAppPrimary  -- alt1\n\n\ninvokePrePost  = invokePrefix  -- alt1\n | invokePostfix  -- alt2\n\n\ninvokePrefix  = not applyExpression  -- alt1\n\n\ninvokePostfix  = invokePostfix atom  -- alt1\n | applyExpression  -- alt2\n\n\napplyExpression  = applyExpression s<\"(\"> list0<expression, s<\",\">> s<\")\">  -- alt1\n | memberExpression  -- alt2\n\n\nmemberExpression  = memberExpression s<\".\"> recordField  -- alt1\n | memberExpression s<\".\"> memberSelection  -- alt2\n | primaryExpression  -- alt3\n\n\nmemberSelection  = s<\"(\"> list1<fieldSelection, s<\",\">> s<\")\">  -- alt1\n\n\nfieldSelection  = recordField as_ recordField  -- alt1\n | recordField  -- alt2\n\n\nprimaryExpression  = newExpression<expression>  -- alt1\n | interpolateExpression  -- alt2\n | literalExpression  -- alt3\n | recordExpression<expression>  -- alt4\n | listExpression<expression>  -- alt5\n | lambdaExpression  -- alt6\n | performExpression  -- alt7\n | hole  -- alt8\n | s<\"#\"> typeAppPrimary  -- alt9\n | return_  -- alt10\n | self_  -- alt11\n | atom  -- alt12\n | name  -- alt13\n | s<\"(\"> expression s<\")\">  -- alt14\n\n\nconditionExpression  = condition_ conditionCase+ end_  -- alt1\n\n\nconditionCase  = when_ expression eblock  -- alt1\n | always_ eblock  -- alt2\n\n\nmatchSearchExpression  = match_ matchSearchCase+ end_  -- alt1\n\n\nmatchSearchCase  = when_ predicate eblock  -- alt1\n | always_ eblock  -- alt2\n\n\nforExpression  = for_ forExprMap  -- alt1\n\n\nforExprMap  = name in_ expression forExprMap1  -- alt1\n\n\nforExprMap1  = s<\",\"> forExprMap  -- alt1\n | if_ expression forExprDo  -- alt2\n | forExprDo  -- alt3\n\n\nforExprDo  = expressionBlock  -- alt1\n\n\nperformExpression  = perform_ atom s<\".\"> atom s<\"(\"> list0<expression, s<\",\">> s<\")\">  -- alt1\n\n\nnewExpression<e>  = new_ atom newFields<e>  -- alt1\n\n\nnewFields<e>  = s<\"(\"> list1<e, s<\",\">> s<\")\">  -- alt1\n |   -- alt2\n\n\nlistExpression<e>  = s<\"[\"> list0<e, s<\",\">> s<\"]\">  -- alt1\n\n\nrecordExpression<e>  = s<\"[\"> s<\"->\"> s<\"]\">  -- alt1\n | s<\"[\"> list1<recordPair<e>, s<\",\">> s<\"]\">  -- alt2\n\n\nrecordPair<e>  = recordField s<\"->\"> e  -- alt1\n\n\nrecordField  = (name | atom)  -- alt1\n | string  -- alt2\n | s<\"[\"> expression s<\"]\">  -- alt3\n\n\nliteralExpression  = literal  -- alt1\n\n\nlambdaExpression  = s<\"{\"> statements s<\"}\">  -- alt1\n | s<\"{\"> list1<name, s<\",\">> in_ statements s<\"}\">  -- alt2\n\n\nhandleExpression  = handle_ statements with_ handlers end_  -- alt1\n\n\nhandlers  = one_handler+  -- alt1\n\n\none_handler  = on_ atom s<\".\"> atom s<\"(\"> list0<name, s<\",\">> s<\")\"> eblock  -- alt1\n\n\natomicExpression  = atom  -- alt1\n | lazyExpression  -- alt2\n | newExpression<atomicExpression>  -- alt3\n | literalExpression  -- alt4\n | recordExpression<atomicExpression>  -- alt5\n | listExpression<atomicExpression>  -- alt6\n\n\nblockExpression  = expressionBlock  -- alt1\n | conditionExpression  -- alt2\n | matchSearchExpression  -- alt3\n | forExpression  -- alt4\n | handleExpression  -- alt5\n\n\ninterpolateExpression  = interpolateText<expression>  -- alt1\n\n\ninterpolateText<t>  = s<\"\\\"\"> interpolatePart<t>* \"\\\"\"  -- alt1\n\n\ninterpolatePart<p>  = \"\\\\\" escape_sequence  -- alt1\n | \"[\" s<p> s<\"]\">  -- alt2\n | ~\"\\\"\" any  -- alt3\n\n\nliteral  = text  -- alt1\n | float  -- alt2\n | integer  -- alt3\n | boolean  -- alt4\n | nothing  -- alt5\n\n\nnothing  = nothing_  -- alt1\n\n\nboolean  = true_  -- alt1\n | false_  -- alt2\n\n\ntext  = string  -- alt1\n\n\ninteger  = s<t_integer>  -- alt1\n\n\nfloat  = s<t_float>  -- alt1\n\n\nstring  = s<t_text>  -- alt1\n\n\nhole  = s<\"_\"> ~name_rest  -- alt1\n\n\natom  = s<\"'\"> t_atom  -- alt1\n | ~reserved s<t_atom> ~\":\"  -- alt2\n\n\nname  = s<t_name>  -- alt1\n\n\nkeyword  = s<t_keyword>  -- alt1\n\n\ninfix_symbol  = s<t_infix_symbol>  -- alt1\n\n\nnot  = not_  -- alt1\n\n\nand  = and_  -- alt1\n\n\nor  = or_  -- alt1\n\n\nas  = as_  -- alt1\n\n\nnamespace  = s<nonemptyListOf<t_atom, s<\".\">>>  -- alt1\n\n\nlogicSignature<t>  = t signaturePair<t>+  -- alt1\n | t atom  -- alt2\n | signaturePair<t>+  -- alt3\n\n\nsignaturePair<t>  = keyword t  -- alt1\n\n\npartialLogicSignature<t>  = signaturePair<t>+  -- alt1\n | atom  -- alt2\n\n\npartialSignature<t>  = signaturePair<t>+  -- alt1\n | infix_symbol t  -- alt2\n | atom  -- alt3\n | not  -- alt4\n\n\nsignature<t>  = t as asParameter  -- alt1\n | t infix_symbol t  -- alt2\n | t signaturePair<t>+  -- alt3\n | t atom  -- alt4\n | not t  -- alt5\n | signaturePair<t>+  -- alt6\n\n\nasParameter  = typeAppPrimary  -- alt1\n\n\nlist0<t, s>  = listOf<t, s> s?  -- alt1\n\n\nlist1<t, s>  = nonemptyListOf<t, s> s?  -- alt1\n\n\nblock<t>  = do_ t* end_  -- alt1\n\n\nstatements  = blockStatement s<\";\">? ws statements1  -- alt1\n | statement ws \";\" ws statements1  -- alt2\n | statement s<\";\">?  -- alt3\n |   -- alt4\n\n\nstatements1  = blockStatement s<\";\">? ws statements1  -- alt1\n | statement ws \";\" ws statements1  -- alt2\n | statement s<\";\">?  -- alt3\n\n\neblock  = do_ statements end_  -- alt1\n | s<\"=>\"> expression s<\";\">  -- alt2\n\n\ns<p>  = space* p  -- alt1\n\n\nws  = space*  -- alt1\n\n\nheader (a file header) = space* \"%\" hs* \"crochet\" nl  -- alt1\n\n\nhs  = \" \"  -- alt1\n | \"\\t\"  -- alt2\n\n\nnl  = \"\\r\\n\"  -- alt1\n | \"\\n\"  -- alt2\n | \"\\r\"  -- alt3\n\n\nline  = (~nl any)*  -- alt1\n\n\ncomment (a comment) = \"//\" ~\"/\" line  -- alt1\n\n\nspace += comment  -- alt1\n\n\ndoc (a documentation comment) = doc_line+  -- alt1\n\n\ndoc_line (a documentation comment) = \"///\" hs? line nl  -- alt1\n\n\nsemi  = s<\";\">  -- alt1\n\n\natom_start  = \"a\"..\"z\"  -- alt1\n\n\natom_rest  = letter  -- alt1\n | digit  -- alt2\n | \"-\"  -- alt3\n\n\nt_atom (an atom) = atom_start atom_rest*  -- alt1\n\n\nt_keyword (a keyword) = t_atom \":\"  -- alt1\n\n\nname_start  = \"A\"..\"Z\"  -- alt1\n | \"_\"  -- alt2\n\n\nname_rest  = letter  -- alt1\n | digit  -- alt2\n | \"-\"  -- alt3\n\n\nt_name (a name) = name_start name_rest*  -- alt1\n\n\nt_infix_symbol  = t_any_infix ~infix_character  -- alt1\n | and_  -- alt2\n | or_  -- alt3\n | as_  -- alt4\n\n\nt_any_infix  = \"++\"  -- alt1\n | \"+\"  -- alt2\n | \"<-\"  -- alt3\n | \"-\"  -- alt4\n | \"**\"  -- alt5\n | \"*\"  -- alt6\n | \"/\"  -- alt7\n | \"<=\"  -- alt8\n | \"<\"  -- alt9\n | \">=\"  -- alt10\n | \">\"  -- alt11\n | \"===\"  -- alt12\n | \"=/=\"  -- alt13\n | \"%\"  -- alt14\n\n\ninfix_character  = \"+\"  -- alt1\n | \"-\"  -- alt2\n | \"*\"  -- alt3\n | \"/\"  -- alt4\n | \"<\"  -- alt5\n | \">\"  -- alt6\n | \"=\"  -- alt7\n | \"%\"  -- alt8\n\n\ndec_digit  = \"0\"..\"9\"  -- alt1\n | \"_\"  -- alt2\n\n\nhex_digit  = \"0\"..\"9\"  -- alt1\n | \"a\"..\"f\"  -- alt2\n | \"A\"..\"F\"  -- alt3\n\n\nt_integer (an integer) = ~\"_\" \"-\"? dec_digit+  -- alt1\n\n\nt_float (a floating point number) = ~\"_\" \"-\"? dec_digit+ \".\" dec_digit+  -- alt1\n\n\ntext_character  = \"\\\\\" escape_sequence  -- alt1\n | ~\"\\\"\" any  -- alt2\n\n\nescape_sequence  = \"u\" hex_digit hex_digit hex_digit hex_digit  -- alt1\n | \"x\" hex_digit hex_digit  -- alt2\n | any  -- alt3\n\n\nt_text (a text) = \"\\\"\" text_character* \"\\\"\"  -- alt1\n\n\nkw<w>  = s<w> ~atom_rest  -- alt1\n\n\nrelation_  = kw<\"relation\">  -- alt1\n\n\npredicate_  = kw<\"predicate\">  -- alt1\n\n\nwhen_  = kw<\"when\">  -- alt1\n\n\ndo_  = kw<\"do\">  -- alt1\n\n\ncommand_  = kw<\"command\">  -- alt1\n\n\ntype_  = kw<\"type\">  -- alt1\n\n\nenum_  = kw<\"enum\">  -- alt1\n\n\ndefine_  = kw<\"define\">  -- alt1\n\n\nsingleton_  = kw<\"singleton\">  -- alt1\n\n\nscene_  = kw<\"scene\">  -- alt1\n\n\naction_  = kw<\"action\">  -- alt1\n\n\nlet_  = kw<\"let\">  -- alt1\n\n\nreturn_  = kw<\"return\">  -- alt1\n\n\nfact_  = kw<\"fact\">  -- alt1\n\n\nforget_  = kw<\"forget\">  -- alt1\n\n\nnew_  = kw<\"new\">  -- alt1\n\n\nsearch_  = kw<\"search\">  -- alt1\n\n\nif_  = kw<\"if\">  -- alt1\n\n\nthen_  = kw<\"then\">  -- alt1\n\n\nelse_  = kw<\"else\">  -- alt1\n\n\ngoto_  = kw<\"goto\">  -- alt1\n\n\ncall_  = kw<\"call\">  -- alt1\n\n\nsimulate_  = kw<\"simulate\">  -- alt1\n\n\nmatch_  = kw<\"match\">  -- alt1\n\n\ntrue_  = kw<\"true\">  -- alt1\n\n\nfalse_  = kw<\"false\">  -- alt1\n\n\nnot_  = kw<\"not\">  -- alt1\n\n\nand_  = kw<\"and\">  -- alt1\n\n\nor_  = kw<\"or\">  -- alt1\n\n\nis_  = kw<\"is\">  -- alt1\n\n\nself_  = kw<\"self\">  -- alt1\n\n\nas_  = kw<\"as\">  -- alt1\n\n\nevent_  = kw<\"event\">  -- alt1\n\n\nquiescence_  = kw<\"quiescence\">  -- alt1\n\n\nfor_  = kw<\"for\">  -- alt1\n\n\nuntil_  = kw<\"until\">  -- alt1\n\n\nin_  = kw<\"in\">  -- alt1\n\n\nforeign_  = kw<\"foreign\">  -- alt1\n\n\non_  = kw<\"on\">  -- alt1\n\n\nalways_  = kw<\"always\">  -- alt1\n\n\ncondition_  = kw<\"condition\">  -- alt1\n\n\nend_  = kw<\"end\">  -- alt1\n\n\nprelude_  = kw<\"prelude\">  -- alt1\n\n\nwith_  = kw<\"with\">  -- alt1\n\n\ntags_  = kw<\"tags\">  -- alt1\n\n\nrank_  = kw<\"rank\">  -- alt1\n\n\nabstract_  = kw<\"abstract\">  -- alt1\n\n\nlazy_  = kw<\"lazy\">  -- alt1\n\n\nforce_  = kw<\"force\">  -- alt1\n\n\ncontext_  = kw<\"context\">  -- alt1\n\n\nsample_  = kw<\"sample\">  -- alt1\n\n\nof_  = kw<\"of\">  -- alt1\n\n\nopen_  = kw<\"open\">  -- alt1\n\n\nlocal_  = kw<\"local\">  -- alt1\n\n\ntest_  = kw<\"test\">  -- alt1\n\n\nassert_  = kw<\"assert\">  -- alt1\n\n\nrequires_  = kw<\"requires\">  -- alt1\n\n\nensures_  = kw<\"ensures\">  -- alt1\n\n\nnothing_  = kw<\"nothing\">  -- alt1\n\n\neffect_  = kw<\"effect\">  -- alt1\n\n\nhandle_  = kw<\"handle\">  -- alt1\n\n\ncontinue_  = kw<\"continue\">  -- alt1\n\n\nperform_  = kw<\"perform\">  -- alt1\n\n\nreserved  = relation_  -- alt1\n | predicate_  -- alt2\n | when_  -- alt3\n | do_  -- alt4\n | command_  -- alt5\n | scene_  -- alt6\n | action_  -- alt7\n | type_  -- alt8\n | enum_  -- alt9\n | define_  -- alt10\n | singleton_  -- alt11\n | goto_  -- alt12\n | call_  -- alt13\n | let_  -- alt14\n | return_  -- alt15\n | fact_  -- alt16\n | forget_  -- alt17\n | new_  -- alt18\n | search_  -- alt19\n | if_  -- alt20\n | simulate_  -- alt21\n | true_  -- alt22\n | false_  -- alt23\n | not_  -- alt24\n | and_  -- alt25\n | or_  -- alt26\n | is_  -- alt27\n | self_  -- alt28\n | as_  -- alt29\n | event_  -- alt30\n | quiescence_  -- alt31\n | for_  -- alt32\n | until_  -- alt33\n | in_  -- alt34\n | foreign_  -- alt35\n | on_  -- alt36\n | always_  -- alt37\n | match_  -- alt38\n | then_  -- alt39\n | else_  -- alt40\n | condition_  -- alt41\n | end_  -- alt42\n | prelude_  -- alt43\n | with_  -- alt44\n | tags_  -- alt45\n | rank_  -- alt46\n | abstract_  -- alt47\n | lazy_  -- alt48\n | force_  -- alt49\n | context_  -- alt50\n | sample_  -- alt51\n | of_  -- alt52\n | open_  -- alt53\n | local_  -- alt54\n | test_  -- alt55\n | assert_  -- alt56\n | requires_  -- alt57\n | ensures_  -- alt58\n | nothing_  -- alt59\n | effect_  -- alt60\n | handle_  -- alt61\n | continue_  -- alt62\n | perform_  -- alt63\n\r\n  }\r\n  ")
+  export const grammar = Ohm.grammar("\r\n  Crochet {\r\n    program  = header declaration* space* end  -- alt1\n\n\nrepl  = ws declaration+ ws end  -- alt1\n | ws statements1 ws end  -- alt2\n | ws replCommand ws end  -- alt3\n\n\nreplCommand  = \":rollback\" hs+ signature<hole>  -- alt1\n | \":help\" hs+ command_ signature<parameter>  -- alt2\n | \":help\" hs+ type_ typeApp  -- alt3\n\n\ndeclarationMeta  = ws meta_doc  -- alt1\n\n\nmeta_doc  = doc  -- alt1\n |   -- alt2\n\n\ndeclaration  = relationDeclaration  -- alt1\n | doDeclaration  -- alt2\n | commandDeclaration  -- alt3\n | typeDeclaration  -- alt4\n | defineDeclaration  -- alt5\n | actionDeclaration  -- alt6\n | whenDeclaration  -- alt7\n | contextDeclaration  -- alt8\n | openDeclaration  -- alt9\n | localDeclaration  -- alt10\n | testDeclaration  -- alt11\n | effectDeclaration  -- alt12\n\n\neffectDeclaration  = declarationMeta effect_ atom with_ effectCase+ end_  -- alt1\n\n\neffectCase  = declarationMeta atom typeParams s<\";\">  -- alt1\n\n\ntypeParams  = s<\"(\"> list0<typeField, s<\",\">> s<\")\">  -- alt1\n\n\ntestDeclaration  = test_ string do_ statements end_  -- alt1\n\n\ntrailingTest  = oneTrailingTest  -- alt1\n | s<\";\">  -- alt2\n\n\noneTrailingTest  = test_ statements end_  -- alt1\n\n\nlocalDeclaration  = local_ defineDeclaration  -- alt1\n | local_ typeDeclaration  -- alt2\n\n\nopenDeclaration  = open_ namespace s<\";\">  -- alt1\n\n\nrelationDeclaration  = declarationMeta ws relation_ logicSignature<relationPart> s<\";\">  -- alt1\n\n\nrelationPart  = name s<\"*\">  -- alt1\n | name  -- alt2\n\n\ndoDeclaration  = prelude_ statements end_  -- alt1\n\n\ncommandDeclaration  = declarationMeta ws command_ signature<parameter> contractDefinition s<\"=\"> expression trailingTest  -- alt1\n | declarationMeta ws command_ signature<parameter> contractDefinition do_ statements oneTrailingTest  -- alt2\n | declarationMeta ws command_ signature<parameter> contractDefinition do_ statements end_  -- alt3\n\n\ncontractDefinition  = retContractDefinition preContractDefinition postContractDefinition  -- alt1\n\n\nretContractDefinition  = s<\"->\"> typeAppPrimary  -- alt1\n |   -- alt2\n\n\npreContractDefinition  = requires_ list1<contractCondition, s<\";\">>  -- alt1\n |   -- alt2\n\n\npostContractDefinition  = ensures_ list1<contractCondition, s<\";\">>  -- alt1\n |   -- alt2\n\n\ncontractCondition  = atom s<\"::\"> expression  -- alt1\n\n\nparameter  = name  -- alt1\n | s<\"(\"> name is_ typeApp s<\")\">  -- alt2\n | typeAppStatic  -- alt3\n\n\ntypeApp  = typeAppStatic  -- alt1\n\n\ntypeAppStatic  = s<\"#\"> typeAppPrimary  -- alt1\n | typeAppPrimary  -- alt2\n\n\ntypeAppPrimary  = typeName  -- alt1\n\n\ntypeName  = atom  -- alt1\n | nothing_  -- alt2\n | true_  -- alt3\n | false_  -- alt4\n\n\ntypeDeclaration  = declarationMeta ws type_ typeName s<\"=\"> foreign_ namespace s<\";\">  -- alt1\n | declarationMeta ws enum_ typeName s<\"=\"> nonemptyListOf<typeName, s<\",\">> s<\";\">  -- alt2\n | declarationMeta ws abstract_ basicType s<\";\">  -- alt3\n | declarationMeta ws singleton_ basicType typeInitBlock  -- alt4\n | declarationMeta ws type_ basicType typeFields s<\";\">  -- alt5\n\n\nbasicType  = atom typeDefParent  -- alt1\n\n\ntypeDefParent  = is_ typeApp  -- alt1\n |   -- alt2\n\n\ntypeInitBlock  = with_ typeInit* end_  -- alt1\n | s<\";\">  -- alt2\n\n\ntypeFields  = s<\"(\"> list1<typeField, s<\",\">> s<\")\">  -- alt1\n |   -- alt2\n\n\ntypeField  = typeFieldName is_ typeApp  -- alt1\n | typeFieldName  -- alt2\n\n\ntypeFieldName  = name  -- alt1\n | atom  -- alt2\n\n\ntypeInit  = partialLogicSignature<invokePostfix> s<\";\">  -- alt1\n | typeInitCommand  -- alt2\n\n\ntypeInitCommand  = declarationMeta ws command_ partialSignature<parameter> contractDefinition s<\"=\"> s<expression> trailingTest  -- alt1\n | declarationMeta ws command_ partialSignature<parameter> contractDefinition do_ statements oneTrailingTest  -- alt2\n | declarationMeta ws command_ partialSignature<parameter> contractDefinition do_ statements end_  -- alt3\n\n\ndefineDeclaration  = declarationMeta ws define_ atom s<\"=\"> s<atomicExpression> s<\";\">  -- alt1\n\n\nactionDeclaration  = declarationMeta ws action_ parameter atom interpolateExpression? actionPredicate actionRank do_ statements actionInit end_  -- alt1\n\n\nactionPredicate  = when_ predicate  -- alt1\n |   -- alt2\n\n\nactionRank  = rank_ s<expression>  -- alt1\n |   -- alt2\n\n\nactionInit  = with_ typeInitCommand*  -- alt1\n |   -- alt2\n\n\nwhenDeclaration  = declarationMeta ws when_ predicate do_ statements end_  -- alt1\n\n\ncontextDeclaration  = declarationMeta ws context_ atom with_ contextItem* end_  -- alt1\n\n\ncontextItem  = actionDeclaration  -- alt1\n | whenDeclaration  -- alt2\n\n\npredicate  = predicateBinary  -- alt1\n\n\npredicateBinary  = predicateAnd  -- alt1\n | predicateOr  -- alt2\n | predicateNot  -- alt3\n\n\npredicateAnd  = predicateNot s<\",\"> predicateAnd1  -- alt1\n\n\npredicateAnd1  = predicateNot s<\",\"> predicateAnd1  -- alt1\n | predicateNot  -- alt2\n\n\npredicateOr  = predicateNot s<\"|\"> predicateOr1  -- alt1\n\n\npredicateOr1  = predicateNot s<\"|\"> predicateOr1  -- alt1\n | predicateNot  -- alt2\n\n\npredicateNot  = not_ predicateConstrain  -- alt1\n | predicateConstrain  -- alt2\n\n\npredicateConstrain  = predicateLet if_ s<expression>  -- alt1\n | if_ s<expression>  -- alt2\n | predicateLet  -- alt3\n | predicateSample  -- alt4\n | predicateType  -- alt5\n | predicatePrimary  -- alt6\n\n\npredicateType  = name is_ typeApp  -- alt1\n\n\npredicateLet  = let_ name s<\"=\"> s<expression>  -- alt1\n\n\npredicateSample  = sample_ integer of_ samplingPool  -- alt1\n\n\nsamplingPool  = logicSignature<pattern>  -- alt1\n | name is_ typeApp  -- alt2\n\n\npredicatePrimary  = always_  -- alt1\n | logicSignature<pattern>  -- alt2\n | s<\"(\"> predicate s<\")\">  -- alt3\n\n\npattern  = s<\"(\"> patternComplex s<\")\">  -- alt1\n | atom  -- alt2\n | self_  -- alt3\n | literal  -- alt4\n | patternName  -- alt5\n\n\npatternComplex  = patternName is_ typeApp  -- alt1\n\n\npatternName  = s<\"_\">  -- alt1\n | name  -- alt2\n\n\nstatement  = s<letStatement>  -- alt1\n | s<factStatement>  -- alt2\n | s<forgetStatement>  -- alt3\n | s<simulateStatement>  -- alt4\n | s<assertStatement>  -- alt5\n | s<expression>  -- alt6\n\n\nblockStatement  = blockExpression  -- alt1\n\n\nletStatement  = let_ name s<\"=\"> s<expression>  -- alt1\n\n\nfactStatement  = fact_ logicSignature<primaryExpression>  -- alt1\n\n\nforgetStatement  = forget_ logicSignature<primaryExpression>  -- alt1\n\n\nsimulateStatement  = simulate_ for_ expression simulateContext until_ simulateGoal signal*  -- alt1\n\n\nsimulateContext  = in_ atom  -- alt1\n |   -- alt2\n\n\nsimulateGoal  = action_ quiescence_  -- alt1\n | event_ quiescence_  -- alt2\n | quiescence_  -- alt3\n | predicate  -- alt4\n\n\nsignal  = on_ signature<parameter> do_ statements end_  -- alt1\n\n\nassertStatement  = assert_ expression  -- alt1\n\n\nexpression  = blockExpression  -- alt1\n | s<searchExpression>  -- alt2\n | s<lazyExpression>  -- alt3\n | s<forceExpression>  -- alt4\n | s<foreignExpression>  -- alt5\n | s<continueWithExpression>  -- alt6\n | s<pipeExpression>  -- alt7\n\n\nsearchExpression  = search_ predicate  -- alt1\n\n\nlazyExpression  = lazy_ expression  -- alt1\n\n\nforceExpression  = force_ expression  -- alt1\n\n\nforeignExpression  = foreign_ namespace s<\"(\"> list0<expression, s<\",\">> s<\")\">  -- alt1\n\n\ncontinueWithExpression  = continue_ with_ pipeExpression  -- alt1\n\n\nexpressionBlock  = do_ statements end_  -- alt1\n\n\npipeExpression  = pipeExpression s<\"|>\"> invokeInfixExpression  -- alt1\n | pipeExpression s<\"|\"> partialSignature<invokePostfix>  -- alt2\n | invokeInfixExpression  -- alt3\n\n\ninvokeInfixExpression  = invokeMixfix s<\"=:=\"> invokeMixfix  -- alt1\n | invokeInfixExpression infix_symbol invokeMixfix  -- alt2\n | invokeMixfix  -- alt3\n\n\ninvokeMixfix  = castExpression signaturePair<invokePostfix>+  -- alt1\n | signaturePair<invokePostfix>+  -- alt2\n | castExpression  -- alt3\n\n\ncastExpression  = invokePrePost as castType  -- alt1\n | invokePrePost is_ typeAppPrimary  -- alt2\n | invokePrePost  -- alt3\n\n\ncastType  = typeAppPrimary  -- alt1\n\n\ninvokePrePost  = invokePrefix  -- alt1\n | invokePostfix  -- alt2\n\n\ninvokePrefix  = not applyExpression  -- alt1\n\n\ninvokePostfix  = invokePostfix atom  -- alt1\n | applyExpression  -- alt2\n\n\napplyExpression  = applyExpression s<\"(\"> list0<expression, s<\",\">> s<\")\">  -- alt1\n | memberExpression  -- alt2\n\n\nmemberExpression  = memberExpression s<\".\"> recordField  -- alt1\n | memberExpression s<\".\"> memberSelection  -- alt2\n | primaryExpression  -- alt3\n\n\nmemberSelection  = s<\"(\"> list1<fieldSelection, s<\",\">> s<\")\">  -- alt1\n\n\nfieldSelection  = recordField as_ recordField  -- alt1\n | recordField  -- alt2\n\n\nprimaryExpression  = newExpression<expression>  -- alt1\n | interpolateExpression  -- alt2\n | literalExpression  -- alt3\n | recordExpression<expression>  -- alt4\n | listExpression<expression>  -- alt5\n | lambdaExpression  -- alt6\n | performExpression  -- alt7\n | hole  -- alt8\n | s<\"#\"> typeAppPrimary  -- alt9\n | return_  -- alt10\n | self_  -- alt11\n | atom  -- alt12\n | name  -- alt13\n | s<\"(\"> expression s<\")\">  -- alt14\n\n\nconditionExpression  = condition_ conditionCase+ end_  -- alt1\n\n\nconditionCase  = when_ expression eblock  -- alt1\n | always_ eblock  -- alt2\n\n\nmatchSearchExpression  = match_ matchSearchCase+ end_  -- alt1\n\n\nmatchSearchCase  = when_ predicate eblock  -- alt1\n | always_ eblock  -- alt2\n\n\nforExpression  = for_ forExprMap  -- alt1\n\n\nforExprMap  = name in_ expression forExprMap1  -- alt1\n\n\nforExprMap1  = s<\",\"> forExprMap  -- alt1\n | if_ expression forExprDo  -- alt2\n | forExprDo  -- alt3\n\n\nforExprDo  = expressionBlock  -- alt1\n\n\nperformExpression  = perform_ atom s<\".\"> atom s<\"(\"> list0<expression, s<\",\">> s<\")\">  -- alt1\n\n\nnewExpression<e>  = new_ atom newFields<e>  -- alt1\n\n\nnewFields<e>  = s<\"(\"> list1<e, s<\",\">> s<\")\">  -- alt1\n |   -- alt2\n\n\nlistExpression<e>  = s<\"[\"> list0<e, s<\",\">> s<\"]\">  -- alt1\n\n\nrecordExpression<e>  = s<\"[\"> s<\"->\"> s<\"]\">  -- alt1\n | s<\"[\"> list1<recordPair<e>, s<\",\">> s<\"]\">  -- alt2\n\n\nrecordPair<e>  = recordField s<\"->\"> e  -- alt1\n\n\nrecordField  = (name | atom)  -- alt1\n | string  -- alt2\n | s<\"[\"> expression s<\"]\">  -- alt3\n\n\nliteralExpression  = literal  -- alt1\n\n\nlambdaExpression  = s<\"{\"> statements s<\"}\">  -- alt1\n | s<\"{\"> list1<name, s<\",\">> in_ statements s<\"}\">  -- alt2\n\n\nhandleExpression  = handle_ statements with_ handlers end_  -- alt1\n\n\nhandlers  = one_handler+  -- alt1\n\n\none_handler  = on_ atom s<\".\"> atom s<\"(\"> list0<name, s<\",\">> s<\")\"> eblock  -- alt1\n\n\natomicExpression  = atom  -- alt1\n | lazyExpression  -- alt2\n | newExpression<atomicExpression>  -- alt3\n | literalExpression  -- alt4\n | recordExpression<atomicExpression>  -- alt5\n | listExpression<atomicExpression>  -- alt6\n\n\nblockExpression  = expressionBlock  -- alt1\n | conditionExpression  -- alt2\n | matchSearchExpression  -- alt3\n | forExpression  -- alt4\n | handleExpression  -- alt5\n | dslExpression  -- alt6\n\n\ninterpolateExpression  = interpolateText<expression>  -- alt1\n\n\ninterpolateText<t>  = s<\"\\\"\"> interpolatePart<t>* \"\\\"\"  -- alt1\n\n\ninterpolatePart<p>  = \"\\\\\" escape_sequence  -- alt1\n | \"[\" s<p> s<\"]\">  -- alt2\n | ~\"\\\"\" any  -- alt3\n\n\ndslExpression  = dsl_ typeApp with_ dslNodeList end_  -- alt1\n\n\ndslNodeList  = list0<dslNode, s<\";\">>  -- alt1\n\n\ndslNode  = dslSignature<dslPrimary> dslAttribute*  -- alt1\n | dslPrimary  -- alt2\n\n\ndslPrimary  = name  -- alt1\n | literal  -- alt2\n | dslCrochet  -- alt3\n | dslNodeTuple  -- alt4\n | s<\"(\"> dslNode s<\")\">  -- alt5\n\n\ndslNodeTuple  = s<\"[\"> dslNodeList s<\"]\">  -- alt1\n\n\ndslCrochet  = s<\"@(\"> expression s<\")\">  -- alt1\n\n\ndslAttribute  = attribute dslPrimary  -- alt1\n\n\ndslSignature<t>  = atom dslSignatureComponent<t>+  -- alt1\n\n\ndslSignatureComponent<t>  = atom  -- alt1\n | dslPrimary  -- alt2\n\n\nliteral  = text  -- alt1\n | float  -- alt2\n | integer  -- alt3\n | boolean  -- alt4\n | nothing  -- alt5\n\n\nnothing  = nothing_  -- alt1\n\n\nboolean  = true_  -- alt1\n | false_  -- alt2\n\n\ntext  = string  -- alt1\n\n\ninteger  = s<t_integer>  -- alt1\n\n\nfloat  = s<t_float>  -- alt1\n\n\nstring  = s<t_text>  -- alt1\n\n\nhole  = s<\"_\"> ~name_rest  -- alt1\n\n\natom  = s<\"'\"> t_atom  -- alt1\n | ~reserved s<t_atom> ~\":\"  -- alt2\n\n\nname  = s<t_name>  -- alt1\n\n\nkeyword  = s<t_keyword>  -- alt1\n\n\nattribute  = s<t_attribute>  -- alt1\n\n\ninfix_symbol  = s<t_infix_symbol>  -- alt1\n\n\nnot  = not_  -- alt1\n\n\nand  = and_  -- alt1\n\n\nor  = or_  -- alt1\n\n\nas  = as_  -- alt1\n\n\nnamespace  = s<nonemptyListOf<t_atom, s<\".\">>>  -- alt1\n\n\nlogicSignature<t>  = t signaturePair<t>+  -- alt1\n | t atom  -- alt2\n | signaturePair<t>+  -- alt3\n\n\nsignaturePair<t>  = keyword t  -- alt1\n\n\npartialLogicSignature<t>  = signaturePair<t>+  -- alt1\n | atom  -- alt2\n\n\npartialSignature<t>  = signaturePair<t>+  -- alt1\n | infix_symbol t  -- alt2\n | atom  -- alt3\n | not  -- alt4\n\n\nsignature<t>  = t as asParameter  -- alt1\n | t infix_symbol t  -- alt2\n | t signaturePair<t>+  -- alt3\n | t atom  -- alt4\n | not t  -- alt5\n | signaturePair<t>+  -- alt6\n\n\nasParameter  = typeAppPrimary  -- alt1\n\n\nlist0<t, s>  = listOf<t, s> s?  -- alt1\n\n\nlist1<t, s>  = nonemptyListOf<t, s> s?  -- alt1\n\n\nblock<t>  = do_ t* end_  -- alt1\n\n\nstatements  = blockStatement s<\";\">? ws statements1  -- alt1\n | statement ws \";\" ws statements1  -- alt2\n | statement s<\";\">?  -- alt3\n |   -- alt4\n\n\nstatements1  = blockStatement s<\";\">? ws statements1  -- alt1\n | statement ws \";\" ws statements1  -- alt2\n | statement s<\";\">?  -- alt3\n\n\neblock  = do_ statements end_  -- alt1\n | s<\"=>\"> expression s<\";\">  -- alt2\n\n\ns<p>  = space* p  -- alt1\n\n\nws  = space*  -- alt1\n\n\nheader (a file header) = space* \"%\" hs* \"crochet\" nl  -- alt1\n\n\nhs  = \" \"  -- alt1\n | \"\\t\"  -- alt2\n\n\nnl  = \"\\r\\n\"  -- alt1\n | \"\\n\"  -- alt2\n | \"\\r\"  -- alt3\n\n\nline  = (~nl any)*  -- alt1\n\n\ncomment (a comment) = \"//\" ~\"/\" line  -- alt1\n\n\nspace += comment  -- alt1\n\n\ndoc (a documentation comment) = doc_line+  -- alt1\n\n\ndoc_line (a documentation comment) = \"///\" hs? line nl  -- alt1\n\n\nsemi  = s<\";\">  -- alt1\n\n\natom_start  = \"a\"..\"z\"  -- alt1\n\n\natom_rest  = letter  -- alt1\n | digit  -- alt2\n | \"-\"  -- alt3\n\n\nt_atom (an atom) = atom_start atom_rest*  -- alt1\n\n\nt_keyword (a keyword) = t_atom \":\"  -- alt1\n\n\nt_attribute (an attribute) = \"--\" ~\"-\" t_atom  -- alt1\n\n\nname_start  = \"A\"..\"Z\"  -- alt1\n | \"_\"  -- alt2\n\n\nname_rest  = letter  -- alt1\n | digit  -- alt2\n | \"-\"  -- alt3\n\n\nt_name (a name) = name_start name_rest*  -- alt1\n\n\nt_infix_symbol  = t_any_infix ~infix_character  -- alt1\n | and_  -- alt2\n | or_  -- alt3\n | as_  -- alt4\n\n\nt_any_infix  = \"++\"  -- alt1\n | \"+\"  -- alt2\n | \"<-\"  -- alt3\n | \"-\"  -- alt4\n | \"**\"  -- alt5\n | \"*\"  -- alt6\n | \"/\"  -- alt7\n | \"<=\"  -- alt8\n | \"<\"  -- alt9\n | \">=\"  -- alt10\n | \">\"  -- alt11\n | \"===\"  -- alt12\n | \"=/=\"  -- alt13\n | \"%\"  -- alt14\n\n\ninfix_character  = \"+\"  -- alt1\n | \"-\"  -- alt2\n | \"*\"  -- alt3\n | \"/\"  -- alt4\n | \"<\"  -- alt5\n | \">\"  -- alt6\n | \"=\"  -- alt7\n | \"%\"  -- alt8\n\n\ndec_digit  = \"0\"..\"9\"  -- alt1\n | \"_\"  -- alt2\n\n\nhex_digit  = \"0\"..\"9\"  -- alt1\n | \"a\"..\"f\"  -- alt2\n | \"A\"..\"F\"  -- alt3\n\n\nt_integer (an integer) = ~\"_\" \"-\"? dec_digit+  -- alt1\n\n\nt_float (a floating point number) = ~\"_\" \"-\"? dec_digit+ \".\" dec_digit+  -- alt1\n\n\ntext_character  = \"\\\\\" escape_sequence  -- alt1\n | ~\"\\\"\" any  -- alt2\n\n\nescape_sequence  = \"u\" hex_digit hex_digit hex_digit hex_digit  -- alt1\n | \"x\" hex_digit hex_digit  -- alt2\n | any  -- alt3\n\n\nt_text (a text) = \"\\\"\" text_character* \"\\\"\"  -- alt1\n\n\nkw<w>  = s<w> ~atom_rest  -- alt1\n\n\nrelation_  = kw<\"relation\">  -- alt1\n\n\npredicate_  = kw<\"predicate\">  -- alt1\n\n\nwhen_  = kw<\"when\">  -- alt1\n\n\ndo_  = kw<\"do\">  -- alt1\n\n\ncommand_  = kw<\"command\">  -- alt1\n\n\ntype_  = kw<\"type\">  -- alt1\n\n\nenum_  = kw<\"enum\">  -- alt1\n\n\ndefine_  = kw<\"define\">  -- alt1\n\n\nsingleton_  = kw<\"singleton\">  -- alt1\n\n\nscene_  = kw<\"scene\">  -- alt1\n\n\naction_  = kw<\"action\">  -- alt1\n\n\nlet_  = kw<\"let\">  -- alt1\n\n\nreturn_  = kw<\"return\">  -- alt1\n\n\nfact_  = kw<\"fact\">  -- alt1\n\n\nforget_  = kw<\"forget\">  -- alt1\n\n\nnew_  = kw<\"new\">  -- alt1\n\n\nsearch_  = kw<\"search\">  -- alt1\n\n\nif_  = kw<\"if\">  -- alt1\n\n\nthen_  = kw<\"then\">  -- alt1\n\n\nelse_  = kw<\"else\">  -- alt1\n\n\ngoto_  = kw<\"goto\">  -- alt1\n\n\ncall_  = kw<\"call\">  -- alt1\n\n\nsimulate_  = kw<\"simulate\">  -- alt1\n\n\nmatch_  = kw<\"match\">  -- alt1\n\n\ntrue_  = kw<\"true\">  -- alt1\n\n\nfalse_  = kw<\"false\">  -- alt1\n\n\nnot_  = kw<\"not\">  -- alt1\n\n\nand_  = kw<\"and\">  -- alt1\n\n\nor_  = kw<\"or\">  -- alt1\n\n\nis_  = kw<\"is\">  -- alt1\n\n\nself_  = kw<\"self\">  -- alt1\n\n\nas_  = kw<\"as\">  -- alt1\n\n\nevent_  = kw<\"event\">  -- alt1\n\n\nquiescence_  = kw<\"quiescence\">  -- alt1\n\n\nfor_  = kw<\"for\">  -- alt1\n\n\nuntil_  = kw<\"until\">  -- alt1\n\n\nin_  = kw<\"in\">  -- alt1\n\n\nforeign_  = kw<\"foreign\">  -- alt1\n\n\non_  = kw<\"on\">  -- alt1\n\n\nalways_  = kw<\"always\">  -- alt1\n\n\ncondition_  = kw<\"condition\">  -- alt1\n\n\nend_  = kw<\"end\">  -- alt1\n\n\nprelude_  = kw<\"prelude\">  -- alt1\n\n\nwith_  = kw<\"with\">  -- alt1\n\n\ntags_  = kw<\"tags\">  -- alt1\n\n\nrank_  = kw<\"rank\">  -- alt1\n\n\nabstract_  = kw<\"abstract\">  -- alt1\n\n\nlazy_  = kw<\"lazy\">  -- alt1\n\n\nforce_  = kw<\"force\">  -- alt1\n\n\ncontext_  = kw<\"context\">  -- alt1\n\n\nsample_  = kw<\"sample\">  -- alt1\n\n\nof_  = kw<\"of\">  -- alt1\n\n\nopen_  = kw<\"open\">  -- alt1\n\n\nlocal_  = kw<\"local\">  -- alt1\n\n\ntest_  = kw<\"test\">  -- alt1\n\n\nassert_  = kw<\"assert\">  -- alt1\n\n\nrequires_  = kw<\"requires\">  -- alt1\n\n\nensures_  = kw<\"ensures\">  -- alt1\n\n\nnothing_  = kw<\"nothing\">  -- alt1\n\n\neffect_  = kw<\"effect\">  -- alt1\n\n\nhandle_  = kw<\"handle\">  -- alt1\n\n\ncontinue_  = kw<\"continue\">  -- alt1\n\n\nperform_  = kw<\"perform\">  -- alt1\n\n\ndsl_  = kw<\"dsl\">  -- alt1\n\n\nreserved  = relation_  -- alt1\n | predicate_  -- alt2\n | when_  -- alt3\n | do_  -- alt4\n | command_  -- alt5\n | scene_  -- alt6\n | action_  -- alt7\n | type_  -- alt8\n | enum_  -- alt9\n | define_  -- alt10\n | singleton_  -- alt11\n | goto_  -- alt12\n | call_  -- alt13\n | let_  -- alt14\n | return_  -- alt15\n | fact_  -- alt16\n | forget_  -- alt17\n | new_  -- alt18\n | search_  -- alt19\n | if_  -- alt20\n | simulate_  -- alt21\n | true_  -- alt22\n | false_  -- alt23\n | not_  -- alt24\n | and_  -- alt25\n | or_  -- alt26\n | is_  -- alt27\n | self_  -- alt28\n | as_  -- alt29\n | event_  -- alt30\n | quiescence_  -- alt31\n | for_  -- alt32\n | until_  -- alt33\n | in_  -- alt34\n | foreign_  -- alt35\n | on_  -- alt36\n | always_  -- alt37\n | match_  -- alt38\n | then_  -- alt39\n | else_  -- alt40\n | condition_  -- alt41\n | end_  -- alt42\n | prelude_  -- alt43\n | with_  -- alt44\n | tags_  -- alt45\n | rank_  -- alt46\n | abstract_  -- alt47\n | lazy_  -- alt48\n | force_  -- alt49\n | context_  -- alt50\n | sample_  -- alt51\n | of_  -- alt52\n | open_  -- alt53\n | local_  -- alt54\n | test_  -- alt55\n | assert_  -- alt56\n | requires_  -- alt57\n | ensures_  -- alt58\n | nothing_  -- alt59\n | effect_  -- alt60\n | handle_  -- alt61\n | continue_  -- alt62\n | perform_  -- alt63\n | dsl_  -- alt64\n\r\n  }\r\n  ")
 
   // == Parsing =======================================================
   export function parse(source: string, rule: string): Result<Program> {
@@ -5503,6 +5765,10 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
       return this.children[0].toAST();
     },
     
+    blockExpression_alt6(this: Ohm.Node, _1: Ohm.Node): any {
+      return this.children[0].toAST();
+    },
+    
   interpolateExpression(x: Ohm.Node): any {
     return x.toAST();
   },
@@ -5538,6 +5804,116 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
     interpolatePart_alt3(this: Ohm.Node, c$0: Ohm.Node): any {
       ; const c = c$0.toAST()
       return (new (((InterpolationPart).Static))($meta(this), c))
+    },
+    
+  dslExpression(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dslExpression_alt1(this: Ohm.Node, _1: Ohm.Node, t$0: Ohm.Node, _3: Ohm.Node, x$0: Ohm.Node, _5: Ohm.Node): any {
+      ; const t = t$0.toAST(); ; const x = x$0.toAST(); 
+      return (new (((Expression).Dsl))($meta(this), t, x))
+    },
+    
+  dslNodeList(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dslNodeList_alt1(this: Ohm.Node, xs$0: Ohm.Node): any {
+      const xs = xs$0.toAST()
+      return xs
+    },
+    
+  dslNode(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dslNode_alt1(this: Ohm.Node, s$0: Ohm.Node, o$0: Ohm.Node): any {
+      const s = s$0.toAST(); const o = o$0.toAST()
+      return (new (((DslAst).Node))($meta(this), s, o))
+    },
+    
+    dslNode_alt2(this: Ohm.Node, _1: Ohm.Node): any {
+      return this.children[0].toAST();
+    },
+    
+  dslPrimary(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dslPrimary_alt1(this: Ohm.Node, n$0: Ohm.Node): any {
+      const n = n$0.toAST()
+      return (new (((DslAst).Var))($meta(this), n))
+    },
+    
+    dslPrimary_alt2(this: Ohm.Node, l$0: Ohm.Node): any {
+      const l = l$0.toAST()
+      return (new (((DslAst).Lit))($meta(this), l))
+    },
+    
+    dslPrimary_alt3(this: Ohm.Node, x$0: Ohm.Node): any {
+      const x = x$0.toAST()
+      return (new (((DslAst).Dynamic))($meta(this), x))
+    },
+    
+    dslPrimary_alt4(this: Ohm.Node, xs$0: Ohm.Node): any {
+      const xs = xs$0.toAST()
+      return (new (((DslAst).List))($meta(this), xs))
+    },
+    
+    dslPrimary_alt5(this: Ohm.Node, _1: Ohm.Node, x$0: Ohm.Node, _3: Ohm.Node): any {
+      ; const x = x$0.toAST(); 
+      return x
+    },
+    
+  dslNodeTuple(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dslNodeTuple_alt1(this: Ohm.Node, _1: Ohm.Node, xs$0: Ohm.Node, _3: Ohm.Node): any {
+      ; const xs = xs$0.toAST(); 
+      return xs
+    },
+    
+  dslCrochet(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dslCrochet_alt1(this: Ohm.Node, _1: Ohm.Node, x$0: Ohm.Node, _3: Ohm.Node): any {
+      ; const x = x$0.toAST(); 
+      return x
+    },
+    
+  dslAttribute(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dslAttribute_alt1(this: Ohm.Node, k$0: Ohm.Node, v$0: Ohm.Node): any {
+      const k = k$0.toAST(); const v = v$0.toAST()
+      return (new (DslAttr)($meta(this), k, v))
+    },
+    
+  dslSignature(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dslSignature_alt1(this: Ohm.Node, n$0: Ohm.Node, xs$0: Ohm.Node): any {
+      const n = n$0.toAST(); const xs = xs$0.toAST()
+      return [(new (((DslSignature).Name))(n)), ...xs]
+    },
+    
+  dslSignatureComponent(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dslSignatureComponent_alt1(this: Ohm.Node, x$0: Ohm.Node): any {
+      const x = x$0.toAST()
+      return (new (((DslSignature).Name))(x))
+    },
+    
+    dslSignatureComponent_alt2(this: Ohm.Node, n$0: Ohm.Node): any {
+      const n = n$0.toAST()
+      return (new (((DslSignature).Child))(n))
     },
     
   literal(x: Ohm.Node): any {
@@ -5660,6 +6036,15 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
   },
   
     keyword_alt1(this: Ohm.Node, x$0: Ohm.Node): any {
+      const x = x$0.toAST()
+      return (new (Name)($meta(this), x))
+    },
+    
+  attribute(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    attribute_alt1(this: Ohm.Node, x$0: Ohm.Node): any {
       const x = x$0.toAST()
       return (new (Name)($meta(this), x))
     },
@@ -6051,6 +6436,14 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
   },
   
     t_keyword_alt1(this: Ohm.Node, _1: Ohm.Node, _2: Ohm.Node): any {
+      return this.sourceString;
+    },
+    
+  t_attribute(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    t_attribute_alt1(this: Ohm.Node, _1: Ohm.Node, _3: Ohm.Node): any {
       return this.sourceString;
     },
     
@@ -6799,6 +7192,14 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
       return this.children[0].toAST();
     },
     
+  dsl_(x: Ohm.Node): any {
+    return x.toAST();
+  },
+  
+    dsl__alt1(this: Ohm.Node, _1: Ohm.Node): any {
+      return this.children[0].toAST();
+    },
+    
   reserved(x: Ohm.Node): any {
     return x.toAST();
   },
@@ -7052,6 +7453,10 @@ function $assert_type<T>(x: any, t: string, f: Typed): asserts x is T {
     },
     
     reserved_alt63(this: Ohm.Node, _1: Ohm.Node): any {
+      return this.children[0].toAST();
+    },
+    
+    reserved_alt64(this: Ohm.Node, _1: Ohm.Node): any {
       return this.children[0].toAST();
     },
     

--- a/source/grammar/crochet.lingua
+++ b/source/grammar/crochet.lingua
@@ -105,6 +105,20 @@ type Expression =
   | Handle(pos: Meta, body: Statement[], handlers: Handler[])
   | Perform(pos: Meta, effect: Name, variant: Name, args: Expression[])
   | ContinueWith(pos: Meta, value: Expression)
+  | Dsl(pos: Meta, language: TypeApp, ast: DslAst[])
+
+type DslAst =
+  | Node(pos: Meta, sig: DslSignature<DslAst>[], attrs: DslAttr[])
+  | Lit(pos: Meta, value: Literal)
+  | Var(pos: Meta, name: Name)
+  | List(pos: Meta, values: DslAst[])
+  | Dynamic(pos: Meta, value: Expression)
+
+type DslSignature<T> =
+  | Name(name: Name)
+  | Child(value: T)
+
+type DslAttr(pos: Meta, key: Name, value: DslAst)
 
 type ForExpression =
   | Map(pos: Meta, name: Name, stream: Expression, body: ForExpression)
@@ -748,6 +762,7 @@ grammar Crochet : Program {
     | matchSearchExpression
     | forExpression
     | handleExpression
+    | dslExpression
 
   interpolateExpression =
     | x:interpolateText<expression> -> Expression.Interpolate(meta, x)
@@ -761,6 +776,42 @@ grammar Crochet : Program {
     | "[" x:s<p> s<"]">          -> InterpolationPart.Dynamic(meta, x)
     | ~"\"" c:any                -> InterpolationPart.Static(meta, c)
 
+
+  // -- DSLs
+  dslExpression =
+    | dsl_ t:typeApp with_ x:dslNodeList end_
+      -> Expression.Dsl(meta, t, x)
+
+  dslNodeList =
+    | xs:list0<dslNode, s<";">> -> xs
+
+  dslNode =
+    | s:dslSignature<dslPrimary> o:dslAttribute*
+      -> DslAst.Node(meta, s, o)
+    | dslPrimary
+
+  dslPrimary =
+    | n:name                    -> DslAst.Var(meta, n)
+    | l:literal                 -> DslAst.Lit(meta, l)
+    | x:dslCrochet              -> DslAst.Dynamic(meta, x)
+    | xs:dslNodeTuple           -> DslAst.List(meta, xs)
+    | s<"("> x:dslNode s<")">   -> x
+
+  dslNodeTuple =
+    | s<"["> xs:dslNodeList s<"]"> -> xs
+
+  dslCrochet =
+    | s<"@("> x:expression s<")"> -> x
+
+  dslAttribute =
+    | k:attribute v:dslPrimary  -> DslAttr(meta, k, v)
+
+  dslSignature<t> =
+    | n:atom xs:dslSignatureComponent<t>+ -> [DslSignature.Name(n), ...xs]
+
+  dslSignatureComponent<t> =
+    | x:atom          -> DslSignature.Name(x)
+    | n:dslPrimary    -> DslSignature.Child(n)
 
   // -- Literals
   literal =
@@ -798,6 +849,7 @@ grammar Crochet : Program {
 
   name = x:s<t_name>                          -> Name(meta, x)
   keyword = x:s<t_keyword>                    -> Name(meta, x)
+  attribute = x:s<t_attribute>                -> Name(meta, x)
   infix_symbol = x:s<t_infix_symbol>          -> Name(meta, x)
   not = x:not_                                -> Name(meta, x)
   and = x:and_                                -> Name(meta, x)
@@ -882,6 +934,8 @@ grammar Crochet : Program {
   token t_atom (an atom) = atom_start atom_rest*
 
   token t_keyword (a keyword) = t_atom ":"
+
+  token t_attribute (an attribute) = "--" ~"-" t_atom
 
   token name_start = "A".."Z" | "_"
   token name_rest = letter | digit | "-"
@@ -994,6 +1048,7 @@ grammar Crochet : Program {
   handle_ = kw<"handle">
   continue_ = kw<"continue">
   perform_ = kw<"perform">
+  dsl_ = kw<"dsl">
 
   reserved =
     | relation_ | predicate_ | when_ | do_ | command_ | scene_ | action_
@@ -1004,5 +1059,5 @@ grammar Crochet : Program {
     | always_ | match_ | then_ | else_ | condition_ | end_ | prelude_ | with_
     | tags_ | rank_ | abstract_ | lazy_ | force_ | context_ | sample_ | of_
     | open_ | local_ | test_ | assert_ | requires_ | ensures_ | nothing_
-    | effect_ | handle_ | continue_ | perform_
+    | effect_ | handle_ | continue_ | perform_ | dsl_
 }

--- a/source/ir/expression.ts
+++ b/source/ir/expression.ts
@@ -52,6 +52,8 @@ export enum OpTag {
   HANDLE,
   PERFORM,
   CONTINUE_WITH,
+
+  DSL,
 }
 
 export enum AssertType {
@@ -102,7 +104,8 @@ export type Op =
   | Simulate
   | Handle
   | Perform
-  | ContinueWith;
+  | ContinueWith
+  | Dsl;
 
 export abstract class BaseOp {
   abstract tag: OpTag;
@@ -471,4 +474,75 @@ export class ContinueWith extends BaseOp {
   constructor(readonly meta: Metadata) {
     super();
   }
+}
+
+export class Dsl extends BaseOp {
+  readonly tag = OpTag.DSL;
+
+  constructor(
+    readonly meta: Metadata,
+    readonly type: Type,
+    readonly ast: DslNode[]
+  ) {
+    super();
+  }
+}
+
+export enum DslNodeTag {
+  NODE = 1,
+  LITERAL,
+  VARIABLE,
+  LIST,
+  EXPRESSION,
+}
+
+export type DslNode =
+  | DslAstNode
+  | DslAstLiteral
+  | DslAstVariable
+  | DslAstExpression
+  | DslAstNodeList;
+
+export type DslMeta = {
+  line: number;
+  column: number;
+};
+
+export class DslAstNode {
+  readonly tag = DslNodeTag.NODE;
+
+  constructor(
+    readonly meta: DslMeta,
+    readonly name: string,
+    readonly children: DslNode[],
+    readonly attributes: Map<string, DslNode>
+  ) {}
+}
+
+export class DslAstLiteral {
+  readonly tag = DslNodeTag.LITERAL;
+
+  constructor(readonly meta: DslMeta, readonly value: Literal) {}
+}
+
+export class DslAstVariable {
+  readonly tag = DslNodeTag.VARIABLE;
+
+  constructor(readonly meta: DslMeta, readonly name: string) {}
+}
+
+export class DslAstNodeList {
+  readonly tag = DslNodeTag.LIST;
+
+  constructor(readonly meta: DslMeta, readonly children: DslNode[]) {}
+}
+
+export class DslAstExpression {
+  readonly tag = DslNodeTag.EXPRESSION;
+
+  constructor(
+    readonly meta: DslMeta,
+    readonly source: string,
+    readonly value: BasicBlock
+  ) {}
 }

--- a/source/vm/boot.ts
+++ b/source/vm/boot.ts
@@ -168,6 +168,67 @@ export function make_universe() {
   const Action = new CrochetType(null, "action", "", Any, [], [], false, null);
   const Effect = new CrochetType(null, "effect", "", null, [], [], false, null);
 
+  const Skeleton = new CrochetType(
+    null,
+    "skeleton",
+    "",
+    Any,
+    [],
+    [],
+    false,
+    null
+  );
+  const SNode = new CrochetType(
+    null,
+    "skeleton-node",
+    "",
+    Skeleton,
+    ["name", "children", "attributes"],
+    [Text, Tuple, Record],
+    false,
+    null
+  );
+  const SLiteral = new CrochetType(
+    null,
+    "skeleton-literal",
+    "",
+    Skeleton,
+    ["value"],
+    [Any],
+    false,
+    null
+  );
+  const SName = new CrochetType(
+    null,
+    "skeleton-name",
+    "",
+    Skeleton,
+    ["name"],
+    [Text],
+    false,
+    null
+  );
+  const SDynamic = new CrochetType(
+    null,
+    "skeleton-dynamic",
+    "",
+    Skeleton,
+    ["thunk"],
+    [Thunk],
+    false,
+    null
+  );
+  const SList = new CrochetType(
+    null,
+    "skeleton-tuple",
+    "",
+    Skeleton,
+    ["children"],
+    [Tuple],
+    false,
+    null
+  );
+
   world.native_types.define("crochet.core/core.any", Any);
   world.native_types.define("crochet.core/core.unknown", Unknown);
   world.native_types.define("crochet.core/core.nothing", Nothing);
@@ -193,6 +254,13 @@ export function make_universe() {
   world.native_types.define("crochet.core/core.cell", Cell);
   world.native_types.define("crochet.core/core.action", Action);
 
+  world.native_types.define("crochet.core/core.skeleton-ast", Skeleton);
+  world.native_types.define("crochet.core/core.skeleton-node", SNode);
+  world.native_types.define("crochet.core/core.skeleton-name", SName);
+  world.native_types.define("crochet.core/core.skeleton-literal", SLiteral);
+  world.native_types.define("crochet.core/core.skeleton-dynamic", SDynamic);
+  world.native_types.define("crochet.core/core.skeleton-tuple", SList);
+
   return new Universe(world, XorShift.new_random(), {
     Any,
     Unknown,
@@ -213,6 +281,13 @@ export function make_universe() {
     Cell,
     Action,
     Effect,
+    Skeleton: {
+      Node: SNode,
+      Name: SName,
+      Literal: SLiteral,
+      Dynamic: SDynamic,
+      Tuple: SList,
+    },
   });
 }
 

--- a/source/vm/intrinsics.ts
+++ b/source/vm/intrinsics.ts
@@ -680,6 +680,13 @@ export class Universe {
       Cell: CrochetType;
       Action: CrochetType;
       Effect: CrochetType;
+      Skeleton: {
+        Node: CrochetType;
+        Name: CrochetType;
+        Literal: CrochetType;
+        Dynamic: CrochetType;
+        Tuple: CrochetType;
+      };
     }
   ) {
     this.nothing = new CrochetValue(Tag.NOTHING, types.Nothing, null);

--- a/source/vm/primitives/dsl.ts
+++ b/source/vm/primitives/dsl.ts
@@ -1,0 +1,72 @@
+import * as IR from "../../ir";
+import { unreachable } from "../../utils/utils";
+import * as Environments from "./environments";
+import {
+  CrochetModule,
+  CrochetValue,
+  Environment,
+  Universe,
+} from "../intrinsics";
+import { materialise_literal } from "./literals";
+import {
+  instantiate,
+  make_record_from_map,
+  make_static_text,
+  make_text,
+  make_thunk,
+  make_tuple,
+} from "./values";
+
+export function reify_dsl_node(
+  universe: Universe,
+  module: CrochetModule,
+  env: Environment,
+  node: IR.DslNode
+): CrochetValue {
+  switch (node.tag) {
+    case IR.DslNodeTag.NODE: {
+      const children = node.children.map((x) =>
+        reify_dsl_node(universe, module, env, x)
+      );
+      const attrs = new Map<string, CrochetValue>();
+      for (const [k, v] of node.attributes) {
+        attrs.set(k, reify_dsl_node(universe, module, env, v));
+      }
+      return instantiate(universe.types.Skeleton.Node, [
+        make_static_text(universe, node.name),
+        make_tuple(universe, children),
+        make_record_from_map(universe, attrs),
+      ]);
+    }
+
+    case IR.DslNodeTag.LITERAL: {
+      return instantiate(universe.types.Skeleton.Literal, [
+        materialise_literal(universe, node.value),
+      ]);
+    }
+
+    case IR.DslNodeTag.VARIABLE: {
+      return instantiate(universe.types.Skeleton.Name, [
+        make_static_text(universe, node.name),
+      ]);
+    }
+
+    case IR.DslNodeTag.EXPRESSION: {
+      return instantiate(universe.types.Skeleton.Dynamic, [
+        make_thunk(universe, env, node.value),
+      ]);
+    }
+
+    case IR.DslNodeTag.LIST: {
+      const children = node.children.map((x) =>
+        reify_dsl_node(universe, module, env, x)
+      );
+      return instantiate(universe.types.Skeleton.Tuple, [
+        make_tuple(universe, children),
+      ]);
+    }
+
+    default:
+      throw unreachable(node, "DSL Node");
+  }
+}

--- a/source/vm/primitives/index.ts
+++ b/source/vm/primitives/index.ts
@@ -12,6 +12,7 @@ import * as Packages from "./packages";
 import * as World from "./world";
 import * as StackTrace from "./stack-trace";
 import * as Effects from "./effect";
+import * as DSL from "./dsl";
 
 export {
   Commands,
@@ -28,4 +29,5 @@ export {
   Values,
   World,
   Effects,
+  DSL,
 };

--- a/stdlib/core/crochet.json
+++ b/stdlib/core/crochet.json
@@ -35,7 +35,8 @@
     "source/indexed.crochet",
     "source/tuple.crochet",
     "source/result.crochet",
-    "source/thunk.crochet"
+    "source/thunk.crochet",
+    "source/skeleton.crochet"
   ],
   "capabilities": {
     "requires": [],

--- a/stdlib/core/source/0-types.crochet
+++ b/stdlib/core/source/0-types.crochet
@@ -63,6 +63,15 @@ type tuple = foreign core.tuple;
 type 'enum = foreign core.enum;
 
 
+// Skeleton-based DSLs
+type skeleton-ast = foreign core.skeleton-ast;
+type skeleton-node = foreign core.skeleton-node;
+type skeleton-name = foreign core.skeleton-name;
+type skeleton-literal = foreign core.skeleton-literal;
+type skeleton-tuple = foreign core.skeleton-tuple;
+type skeleton-dynamic = foreign core.skeleton-dynamic;
+
+
 /// The type of results that may fail
 abstract result;
 type ok is result(value);

--- a/stdlib/core/source/debug-representation.crochet
+++ b/stdlib/core/source/debug-representation.crochet
@@ -75,7 +75,7 @@ command doc nested: (Indent is integer) =
   new doc-nest(Indent, self);
 
 command doc aligned =
-  new doc-dynamic({ Column, Indent in self nested: (Column - Indent) });
+  new doc-dynamic({ Column, Indent in self nested: Column });
 
 command doc break =
   new doc-join(self, doc-break);
@@ -272,7 +272,7 @@ end
 
 command debug-representation of: (X is record) do
   condition
-    when X is-empty => #doc text: "->" | between: "[" and: "]";
+    when X is-empty => #doc text: "->" | between: "\[" and: "\]";
     always do
       let Pairs = X pairs map: { P in
         #doc text: P.key
@@ -309,10 +309,10 @@ command type-representation finish =
 command type-field as doc =
   #doc text: self.name
     | append: " -> "
-    | append: (debug-representation of: self.value);
+    | append: (debug-representation of: self.value | aligned);
 
 command type-pos as doc =
-  debug-representation of: self.value;
+  debug-representation of: self.value | aligned;
 
 command type-representation as doc do
   let Fields = self.fields map: (_ as doc);

--- a/stdlib/core/source/skeleton.crochet
+++ b/stdlib/core/source/skeleton.crochet
@@ -1,0 +1,41 @@
+% crochet
+
+command skeleton-node name = self.name;
+command skeleton-node children = self.children;
+command skeleton-node attributes = self.attributes;
+
+command skeleton-literal value = self.value;
+
+command skeleton-name name = self.name;
+
+command skeleton-dynamic thunk = self.thunk;
+
+command skeleton-tuple children = self.children;
+
+
+command debug-representation of: (X is skeleton-node) =
+  debug-representation type: "skeleton-node"
+    | field: "name" value: X name
+    | field: "children" value: X children
+    | field: "attributes" value: X attributes
+    | finish;
+
+command debug-representation of: (X is skeleton-literal) =
+  debug-representation type: "skeleton-literal"
+    | value: X value
+    | finish;
+
+command debug-representation of: (X is skeleton-name) =
+  debug-representation type: "skeleton-name"
+    | value: X value
+    | finish;
+
+command debug-representation of: (X is skeleton-dynamic) =
+  debug-representation type: "skeleton-dynamic"
+    | value: X thunk
+    | finish;
+
+command debug-representation of: (X is skeleton-tuple) =
+  debug-representation type: "skeleton-tuple"
+    | value: X children
+    | finish;

--- a/support/editors/vscode/crochet/syntaxes/crochet.tmLanguage.json
+++ b/support/editors/vscode/crochet/syntaxes/crochet.tmLanguage.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "name": "keyword.control.crochet",
-      "match": "(?<![a-zA-Z0-9\\-\\.\\^'])(relation|predicate|when|do|command|scene|action|type|enum|define|singleton|goto|call|let|return|fact|forget|new|search|if|simulate|true|false|not|and|or|is|self|as|event|quiescence|for|until|in|foreign|on|always|match|then|else|condition|end|with|prelude|rank|tags|abstract|lazy|force|context|sample|of|open|local|test|assert|requires|ensures|nothing|handle|effect|continue|perform)(?![a-zA-Z0-9\\-:])"
+      "match": "(?<![a-zA-Z0-9\\-\\.\\^'])(relation|predicate|when|do|command|scene|action|type|enum|define|singleton|goto|call|let|return|fact|forget|new|search|if|simulate|true|false|not|and|or|is|self|as|event|quiescence|for|until|in|foreign|on|always|match|then|else|condition|end|with|prelude|rank|tags|abstract|lazy|force|context|sample|of|open|local|test|assert|requires|ensures|nothing|handle|effect|continue|perform|dsl)(?![a-zA-Z0-9\\-:])"
     },
     {
       "name": "constant.language.crochet",

--- a/tests/vm-tests/crochet.json
+++ b/tests/vm-tests/crochet.json
@@ -22,7 +22,8 @@
     "search.crochet",
     "branch.crochet",
     "actions.crochet",
-    "effects.crochet"
+    "effects.crochet",
+    "dsl.crochet"
   ],
   "capabilities": {
     "requires": [],

--- a/tests/vm-tests/dsl.crochet
+++ b/tests/vm-tests/dsl.crochet
@@ -1,0 +1,80 @@
+% crochet
+
+abstract arithmetic;
+
+command #arithmetic evaluate: (X is skeleton-node) do
+  condition
+    when X name =:= "add _ _" do
+      let Left = X children first;
+      let Right = X children second;
+      (self evaluate: Left) + (self evaluate: Right);
+    end
+      
+    when X name =:= "sub _ _" do
+      let Left = X children first;
+      let Right = X children second;
+      (self evaluate: Left) - (self evaluate: Right);
+    end
+
+    when X name =:= "display _" do
+      [ value -> self evaluate: X children first,
+        tag -> (X attributes).tag
+      ]
+    end
+
+    when X name =:= "list _" do
+      self evaluate: X children first;
+    end
+  end
+end
+
+command #arithmetic evaluate: (Xs is tuple) do
+  for X in Xs do self evaluate: X end
+end
+
+command #arithmetic evaluate: (X is skeleton-literal) = X value;
+command #arithmetic evaluate: (X is skeleton-dynamic) = force X thunk;
+command #arithmetic evaluate: (X is skeleton-tuple) =
+  self evaluate: X children;
+
+test "Simple evaluation" do
+  let Result =
+    dsl arithmetic with
+      add 1 (add 2 (sub 3 2))
+    end;
+
+  assert Result =:= [1 + (2 + (3 - 2))];
+end
+
+test "Evaluation with thunks" do
+  let Result =
+    dsl arithmetic with
+      add 1 (add 2 @(3 - 2))
+    end;
+
+  assert Result =:= [1 + (2 + (3 - 2))];
+end
+
+test "Attributes" do
+  let Result =
+    dsl arithmetic with
+      add 1 2 --tag "1 + 2";
+      add 3 4 --tag "3 + 4";
+    end;
+
+  assert Result =:= [
+    [value -> 1 + 2, tag -> "1 + 2"],
+    [value -> 3 + 4, tag -> "3 + 4"]
+  ]
+end
+
+test "List children" do
+  let Result =
+    dsl arithmetic with
+      list [1; 2; 3; 4]
+    end;
+
+  assert Result =:= [
+    [1, 2, 3, 4]
+  ];
+end


### PR DESCRIPTION
This makes embedded languages less work, while at the same time being static enough for tooling support (which means the IDE will be able to use language-specific services to provide ways of interacting and displaying these blocks).