### PR TITLE
Perform hashtable lookups on known values in the search runtime

### DIFF
--- a/source/vm/intrinsics.ts
+++ b/source/vm/intrinsics.ts
@@ -3,6 +3,8 @@ import { unreachable, zip } from "../utils/utils";
 import { XorShift } from "../utils/xorshift";
 import { ITranscript } from "./interfaces";
 import { Namespace, PassthroughNamespace } from "./namespaces";
+// Only imported so callbacks get the correct type here
+import type { Pattern } from "./logic/unification";
 
 export type Primitive = boolean | null | bigint | number;
 
@@ -371,17 +373,10 @@ export class ConcreteRelation {
 
 export class ProceduralRelation {
   constructor(
-    readonly search: (
-      env: Environment,
-      patterns: IR.Pattern[]
-    ) => Environment[],
+    readonly search: (env: Environment, patterns: Pattern[]) => Environment[],
     readonly sample:
       | null
-      | ((
-          env: Environment,
-          patterns: IR.Pattern[],
-          size: number
-        ) => Environment[])
+      | ((env: Environment, patterns: Pattern[], size: number) => Environment[])
   ) {}
 }
 

--- a/source/vm/logic/relations.ts
+++ b/source/vm/logic/relations.ts
@@ -17,6 +17,7 @@ import { Namespace } from "../namespaces";
 import { Location } from "../primitives";
 import { XorShift } from "../../utils/xorshift";
 import { CrochetValue } from "../../crochet";
+import { compile_pattern } from "./unification";
 
 export function define_concrete(
   module: CrochetModule,
@@ -83,8 +84,9 @@ export function search(
   module: CrochetModule,
   env: Environment,
   relation: CrochetRelation,
-  patterns: IR.Pattern[]
+  patterns0: IR.Pattern[]
 ) {
+  const patterns = patterns0.map((p) => compile_pattern(state, module, env, p));
   switch (relation.tag) {
     case RelationTag.CONCRETE: {
       assert_tag(RelationTag.CONCRETE, relation);
@@ -108,8 +110,9 @@ export function sample(
   size: number,
   env: Environment,
   relation: CrochetRelation,
-  patterns: IR.Pattern[]
+  patterns0: IR.Pattern[]
 ) {
+  const patterns = patterns0.map((p) => compile_pattern(state, module, env, p));
   switch (relation.tag) {
     case RelationTag.CONCRETE: {
       assert_tag(RelationTag.CONCRETE, relation);

--- a/source/vm/primitives/values.ts
+++ b/source/vm/primitives/values.ts
@@ -1,12 +1,5 @@
 import * as IR from "../../ir";
-import {
-  clone_map,
-  copy_map,
-  every,
-  unreachable,
-  zip,
-  zip3,
-} from "../../utils/utils";
+import { clone_map, zip, zip3 } from "../../utils/utils";
 import { ErrArbitrary } from "../errors";
 import {
   Action,
@@ -19,6 +12,7 @@ import {
   CrochetType,
   CrochetValue,
   Environment,
+  equals,
   Tag,
   Universe,
 } from "../intrinsics";
@@ -258,92 +252,6 @@ export function get_interpolation_parts(
 ): (string | CrochetValue)[] {
   assert_tag(Tag.INTERPOLATION, x);
   return x.payload;
-}
-
-export function equals(left: CrochetValue, right: CrochetValue): boolean {
-  if (left.tag !== right.tag) {
-    return false;
-  }
-
-  switch (left.tag) {
-    case Tag.NOTHING:
-    case Tag.TRUE:
-    case Tag.FALSE:
-      return left.tag === right.tag;
-
-    case Tag.INTEGER: {
-      assert_tag(Tag.INTEGER, left);
-      assert_tag(Tag.INTEGER, right);
-      return left.payload === right.payload;
-    }
-
-    case Tag.FLOAT_64: {
-      assert_tag(Tag.FLOAT_64, left);
-      assert_tag(Tag.FLOAT_64, right);
-      return left.payload === right.payload;
-    }
-
-    case Tag.PARTIAL: {
-      assert_tag(Tag.PARTIAL, left);
-      assert_tag(Tag.PARTIAL, right);
-      return (
-        left.payload.module === right.payload.module &&
-        left.payload.name === right.payload.name
-      );
-    }
-
-    case Tag.TEXT: {
-      assert_tag(Tag.TEXT, left);
-      assert_tag(Tag.TEXT, right);
-      return left.payload === right.payload;
-    }
-
-    case Tag.INTERPOLATION: {
-      assert_tag(Tag.INTERPOLATION, left);
-      assert_tag(Tag.INTERPOLATION, right);
-      return (
-        left.payload.length === right.payload.length &&
-        every(zip(left.payload, right.payload), ([l, r]) => {
-          if (typeof l === "string" && typeof r === "string") {
-            return l === r;
-          } else if (l instanceof CrochetValue && r instanceof CrochetValue) {
-            return equals(l, r);
-          } else {
-            return false;
-          }
-        })
-      );
-    }
-
-    case Tag.TUPLE: {
-      assert_tag(Tag.TUPLE, left);
-      assert_tag(Tag.TUPLE, right);
-      return (
-        left.payload.length === right.payload.length &&
-        every(zip(left.payload, right.payload), ([l, r]) => equals(l, r))
-      );
-    }
-
-    case Tag.RECORD: {
-      assert_tag(Tag.RECORD, left);
-      assert_tag(Tag.RECORD, right);
-      if (left.payload.size !== right.payload.size) {
-        return false;
-      }
-      for (const [k, v] of left.payload.entries()) {
-        const rv = right.payload.get(k);
-        if (rv == null) {
-          return false;
-        } else if (!equals(v, rv)) {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    default:
-      return left === right;
-  }
 }
 
 export function register_instance(universe: Universe, value: CrochetValue) {
@@ -616,3 +524,5 @@ export function to_number(x: CrochetValue) {
 export function is_nothing(x: CrochetValue) {
   return x.tag === Tag.NOTHING;
 }
+
+export { equals };

--- a/source/vm/simulation/simulation.ts
+++ b/source/vm/simulation/simulation.ts
@@ -213,13 +213,7 @@ function setup_relations(state: SimulationState) {
           if (state.turn == null) {
             return [];
           } else {
-            return unify_all(
-              state.state,
-              state.module,
-              env,
-              [state.turn],
-              pattern
-            );
+            return unify_all(env, [state.turn], pattern);
           }
         }, null),
       ],
@@ -230,7 +224,7 @@ function setup_relations(state: SimulationState) {
             state.state.universe,
             state.rounds
           );
-          return unify_all(state.state, state.module, env, [rounds], pattern);
+          return unify_all(env, [rounds], pattern);
         }, null),
       ],
     ])


### PR DESCRIPTION
This is a very small optimisation (in the absence of a proper query optimiser and more robust database runtime) to perform a simple hashtable lookup when unifying known values. It also moves some of the materialisation of values outside of the unification loop.

The new introduced CMap structure is the least-effort addition to the runtime that supports hash lookups for most values (but not all) without extensive runtime changes, but it has a fair bit of overhead with the key and storage bookkeeping. This overhead (and the overhead of scanning a less ideal memory layout) is still offset (even if very slightly) by avoiding a full scan for values that are fully bound.

The new unification patterns are probably less friendly to v8's PIC-based optimisation, but I haven't checked.