### PR TITLE
Allow postfix unary to follow prefix unary invocations

### DIFF
--- a/source/grammar/crochet.lingua
+++ b/source/grammar/crochet.lingua
@@ -720,11 +720,11 @@ grammar Crochet : Program {
 
   invokePrePost =
     | invokePrefix
-    | invokePostfix
 
   invokePrefix =
-    | n:not p:applyExpression
+    | n:not p:invokePostfix
       -> Expression.Invoke(meta, Signature.Unary(meta, p, n))
+    | invokePostfix
 
   invokePostfix =
     | s:invokePostfix n:atom

--- a/stdlib/crochet.core/source/collection/iteration/foldable-collection.crochet
+++ b/stdlib/crochet.core/source/collection/iteration/foldable-collection.crochet
@@ -25,7 +25,7 @@ end
 
 /// Folds a list using its first element as the initial state.
 command list fold-with: (Fun is function-2)
-requires non-empty :: not (self is-empty)
+requires non-empty :: not self is-empty
 do
   self rest fold-from: self first with: Fun;
 test
@@ -36,7 +36,7 @@ end
 
 /// Folds a list using its last element as the initial state.
 command list fold-right-with: (Fun is function-2)
-requires non-empty :: not (self is-empty)
+requires non-empty :: not self is-empty
 do
   self without-last fold-right-from: self last with: Fun;
 test

--- a/stdlib/crochet.core/source/functional/thunk.crochet
+++ b/stdlib/crochet.core/source/functional/thunk.crochet
@@ -6,9 +6,9 @@ test
   let T1 = lazy 1;
   let T2 = lazy 2;
 
-  assert not (T1 is-forced);
-  assert not (T2 is-forced);
+  assert not T1 is-forced;
+  assert not T2 is-forced;
   force T1;
   assert T1 is-forced;
-  assert not (T2 is-forced);
+  assert not T2 is-forced;
 end

--- a/stdlib/crochet.core/source/numeric/floating-point.crochet
+++ b/stdlib/crochet.core/source/numeric/floating-point.crochet
@@ -4,14 +4,14 @@
 command (X is float) is-nan = foreign float.is-nan(X)
 test
   assert #float nan is-nan;
-  assert not (1.0 is-nan);
+  assert not 1.0 is-nan;
 end
 
 /// True if a floating point value represents a real number.
 command (X is float) is-finite = foreign float.is-finite(X)
 test
-  assert not (#float positive-infinity is-finite);
-  assert not (#float negative-infinity is-finite);
+  assert not #float positive-infinity is-finite;
+  assert not #float negative-infinity is-finite;
   assert 1.0 is-finite;
 end
 

--- a/stdlib/crochet.core/source/text/ascii.crochet
+++ b/stdlib/crochet.core/source/text/ascii.crochet
@@ -14,8 +14,8 @@ command text is-ascii
   = foreign text.is-ascii(self)
 test
   assert "abc" is-ascii;
-  assert not ("á" is-ascii);
-  assert not ("🌷" is-ascii);
+  assert not "á" is-ascii;
+  assert not "🌷" is-ascii;
 end
 
 command ascii-view to-lower-case

--- a/stdlib/crochet.core/source/text/basic.crochet
+++ b/stdlib/crochet.core/source/text/basic.crochet
@@ -2,7 +2,7 @@
 
 command text ends-with: (Text is text)
 requires
-  non-empty :: not (Text is-empty)
+  non-empty :: not Text is-empty
 do
   foreign text.ends-with(self, Text)
 test
@@ -14,7 +14,7 @@ end
 
 command text starts-with: (Text is text)
 requires
-  non-empty :: not (Text is-empty)
+  non-empty :: not Text is-empty
 do
   foreign text.starts-with(self, Text)
 test
@@ -26,7 +26,7 @@ end
 
 command text contains: (Text is text)
 requires
-  non-empty :: not (Text is-empty)
+  non-empty :: not Text is-empty
 do
   foreign text.contains(self, Text)
 test
@@ -81,8 +81,8 @@ command text is-empty =
   self =:= ""
 test
   assert "" is-empty;
-  assert not ("abc" is-empty);
-  assert not ("​" is-empty); // zero-width space (u200B)
+  assert not "abc" is-empty;
+  assert not "​" is-empty; // zero-width space (u200B)
 end
 
 /// Joins a set of texts

--- a/stdlib/crochet.core/source/traits/iteration.crochet
+++ b/stdlib/crochet.core/source/traits/iteration.crochet
@@ -108,7 +108,7 @@ end
 /// The average of all items in the collection. Every item must implement
 /// [arithmetic].
 command (X has foldable-collection, countable-container) average -> float
-requires non-empty :: not (X is-empty)
+requires non-empty :: not X is-empty
 do
   X sum / X count;
 test
@@ -119,7 +119,7 @@ end
 
 /// The highest value in the collection. All values must have a [total-ordering].
 command (X has foldable-collection) maximum
-requires non-empty :: not (X is-empty)
+requires non-empty :: not X is-empty
 do
   X fold-with: (greater-of: _ and: _)
 test
@@ -130,7 +130,7 @@ end
 
 /// The lowest value in the collection. All values must have a [total-ordering].
 command (X has foldable-collection) minimum
-requires non-empty :: not (X is-empty)
+requires non-empty :: not X is-empty
 do
   X fold-with: (lesser-of: _ and: _)
 test

--- a/stdlib/crochet.novella/source/dsl.crochet
+++ b/stdlib/crochet.novella/source/dsl.crochet
@@ -59,7 +59,7 @@ define root-env = lazy new novella-env(nothing, #cell with-value: [
 command novella-env lookup: (Name is text) meta: Meta =
   condition
     when self.bindings value contains-key: Name => (self.bindings value).[Name];
-    when not (self.parent is nothing) => self.parent lookup: Name meta: Meta;
+    when not self.parent is nothing => self.parent lookup: Name meta: Meta;
     always => panic: "[Name] is not defined, at [Meta position-message]" tag: "undefined-name";
   end;
 

--- a/stdlib/crochet.parsing.combinators/source/combinators.crochet
+++ b/stdlib/crochet.parsing.combinators/source/combinators.crochet
@@ -1,13 +1,13 @@
 % crochet
 
 command #parser any-of: (Parsers is list)
-requires non-empty :: not (Parsers is-empty)
+requires non-empty :: not Parsers is-empty
 do
   Parsers rest fold-from: Parsers first with: (_ or _);
 end
 
 command #parser sequence: (Parsers is list)
-requires non-empty :: not (Parsers is-empty)
+requires non-empty :: not Parsers is-empty
 do
   Parsers rest fold-from: Parsers first with: (_ and _)
     | collect;

--- a/stdlib/crochet.random/source/random.crochet
+++ b/stdlib/crochet.random/source/random.crochet
@@ -71,7 +71,7 @@ test
 end
 
 command xor-shift choose: (Items is list)
-requires non-empty :: not (Items is-empty)
+requires non-empty :: not Items is-empty
 do
   let Result = self between: 1 and: Items count;
   let Choice = Items at: Result.value;
@@ -91,7 +91,7 @@ test
 end
 
 command xor-shift choose-and-tear: (Items0 is list)
-requires non-empty :: not (Items0 is-empty)
+requires non-empty :: not Items0 is-empty
 do
   let Result = self between: 1 and: Items0 count;
   let Choice = Items0 at: Result.value;
@@ -132,7 +132,7 @@ test
 end
 
 command xor-shift choose-weighted: (Items0 is list)
-requires non-empty :: not (Items0 is-empty)
+requires non-empty :: not Items0 is-empty
 do
   let Total = Items0.score sum;
   let Items = Items0 sort-by: { A, B in A.score compare-to: B.score };


### PR DESCRIPTION
This lifts the requirement for parenthesis in constructs such as `not list is-empty`, by allowing `list is-empty` to follow a `not` invocation.