### PR TITLE
Check projection and construction capabilities

### DIFF
--- a/source/crochet/crochet.ts
+++ b/source/crochet/crochet.ts
@@ -164,6 +164,9 @@ export class BootedCrochet {
       }
       cpkg.granted_capabilities.add(capability);
     }
+    if (this.graph.trusted.has(pkg.pkg)) {
+      this.universe.trusted_base.add(cpkg);
+    }
   }
 
   private async load_native(

--- a/source/vm/evaluation.ts
+++ b/source/vm/evaluation.ts
@@ -492,7 +492,11 @@ export class Thread {
           op.type
         );
         const type = Capability.free_type(this.module, type0);
-        Capability.assert_construct_capability(this.module, type);
+        Capability.assert_construct_capability(
+          this.universe,
+          this.module,
+          type
+        );
         const value = Values.instantiate(type, values);
         this.push(activation, value);
         activation.next();
@@ -756,7 +760,12 @@ export class Thread {
         const [key0, value0] = this.pop_many(activation, 2);
         const key = Values.text_to_string(key0);
         const result = Values.project(value0, key, (value) =>
-          Capability.assert_projection_capability(this.module, value, key)
+          Capability.assert_projection_capability(
+            this.universe,
+            this.module,
+            value,
+            key
+          )
         );
         this.push(activation, result);
         activation.next();
@@ -766,7 +775,12 @@ export class Thread {
       case t.PROJECT_STATIC: {
         const value = this.pop(activation);
         const result = Values.project(value, op.key, (value) =>
-          Capability.assert_projection_capability(this.module, value, op.key)
+          Capability.assert_projection_capability(
+            this.universe,
+            this.module,
+            value,
+            op.key
+          )
         );
         this.push(activation, result);
         activation.next();

--- a/source/vm/evaluation.ts
+++ b/source/vm/evaluation.ts
@@ -754,7 +754,9 @@ export class Thread {
       case t.PROJECT: {
         const [key0, value0] = this.pop_many(activation, 2);
         const key = Values.text_to_string(key0);
-        const result = Values.project(value0, key);
+        const result = Values.project(value0, key, (value) =>
+          Capability.assert_projection_capability(this.module, value, key)
+        );
         this.push(activation, result);
         activation.next();
         return _continue;
@@ -762,7 +764,9 @@ export class Thread {
 
       case t.PROJECT_STATIC: {
         const value = this.pop(activation);
-        const result = Values.project(value, op.key);
+        const result = Values.project(value, op.key, (value) =>
+          Capability.assert_projection_capability(this.module, value, op.key)
+        );
         this.push(activation, result);
         activation.next();
         return _continue;

--- a/source/vm/evaluation.ts
+++ b/source/vm/evaluation.ts
@@ -492,6 +492,7 @@ export class Thread {
           op.type
         );
         const type = Capability.free_type(this.module, type0);
+        Capability.assert_construct_capability(this.module, type);
         const value = Values.instantiate(type, values);
         this.push(activation, value);
         activation.next();

--- a/source/vm/intrinsics.ts
+++ b/source/vm/intrinsics.ts
@@ -850,6 +850,7 @@ export class Universe {
   readonly false: CrochetValue;
   readonly integer_cache: CrochetValue[];
   readonly float_cache: CrochetValue[];
+  readonly trusted_base = new Set<CrochetPackage>();
 
   constructor(
     readonly trace: CrochetTrace,

--- a/source/vm/primitives/capability.ts
+++ b/source/vm/primitives/capability.ts
@@ -161,16 +161,20 @@ export function assert_projection_capability(
   name: string
 ) {
   const type_pkg = value.type.module?.pkg;
-  if (!type_pkg && !universe.trusted_base.has(module.pkg)) {
-    throw new ErrArbitrary(
-      "lacking-capability",
-      `Projecting ${name} from ${Location.type_name(
-        value.type
-      )} is not possible, as it's an intrinsic type. Intrinsic types can only be managed by the Crochet runtime for security.`
-    );
+  if (!type_pkg) {
+    if (!universe.trusted_base.has(module.pkg)) {
+      throw new ErrArbitrary(
+        "lacking-capability",
+        `Projecting ${name} from ${Location.type_name(
+          value.type
+        )} is not possible, as it's an intrinsic type. Intrinsic types can only be managed by the Crochet runtime for security.`
+      );
+    } else {
+      return;
+    }
   }
 
-  if (module.pkg !== type_pkg && !universe.trusted_base.has(module.pkg)) {
+  if (module.pkg !== type_pkg) {
     throw new ErrArbitrary(
       "lacking-capability",
       `Projecting ${name} from ${Location.type_name(
@@ -188,16 +192,20 @@ export function assert_construct_capability(
   type: CrochetType
 ) {
   const type_pkg = type.module?.pkg;
-  if (!type_pkg && !universe.trusted_base.has(module.pkg)) {
-    throw new ErrArbitrary(
-      "lacking-capability",
-      `Constructing ${Location.type_name(
-        type
-      )} is not possible, as it's an intrinsic type. Intrinsic types can only be constructed by the Crochet runtime for security.`
-    );
+  if (!type_pkg) {
+    if (!universe.trusted_base.has(module.pkg)) {
+      throw new ErrArbitrary(
+        "lacking-capability",
+        `Constructing ${Location.type_name(
+          type
+        )} is not possible, as it's an intrinsic type. Intrinsic types can only be constructed by the Crochet runtime for security.`
+      );
+    } else {
+      return;
+    }
   }
 
-  if (module.pkg !== type_pkg && !universe.trusted_base.has(module.pkg)) {
+  if (module.pkg !== type_pkg) {
     throw new ErrArbitrary(
       "lacking-capability",
       `Constructing ${Location.type_name(

--- a/source/vm/primitives/capability.ts
+++ b/source/vm/primitives/capability.ts
@@ -155,12 +155,13 @@ export function assert_capabilities(
 }
 
 export function assert_projection_capability(
+  universe: Universe,
   module: CrochetModule,
   value: CrochetValue,
   name: string
 ) {
   const type_pkg = value.type.module?.pkg;
-  if (!type_pkg) {
+  if (!type_pkg && !universe.trusted_base.has(module.pkg)) {
     throw new ErrArbitrary(
       "lacking-capability",
       `Projecting ${name} from ${Location.type_name(
@@ -169,7 +170,7 @@ export function assert_projection_capability(
     );
   }
 
-  if (module.pkg !== type_pkg) {
+  if (module.pkg !== type_pkg && !universe.trusted_base.has(module.pkg)) {
     throw new ErrArbitrary(
       "lacking-capability",
       `Projecting ${name} from ${Location.type_name(
@@ -182,11 +183,12 @@ export function assert_projection_capability(
 }
 
 export function assert_construct_capability(
+  universe: Universe,
   module: CrochetModule,
   type: CrochetType
 ) {
   const type_pkg = type.module?.pkg;
-  if (!type_pkg) {
+  if (!type_pkg && !universe.trusted_base.has(module.pkg)) {
     throw new ErrArbitrary(
       "lacking-capability",
       `Constructing ${Location.type_name(
@@ -195,7 +197,7 @@ export function assert_construct_capability(
     );
   }
 
-  if (module.pkg !== type_pkg) {
+  if (module.pkg !== type_pkg && !universe.trusted_base.has(module.pkg)) {
     throw new ErrArbitrary(
       "lacking-capability",
       `Constructing ${Location.type_name(

--- a/source/vm/primitives/capability.ts
+++ b/source/vm/primitives/capability.ts
@@ -153,3 +153,56 @@ export function assert_capabilities(
     )}`
   );
 }
+
+export function assert_projection_capability(
+  module: CrochetModule,
+  value: CrochetValue,
+  name: string
+) {
+  const type_pkg = value.type.module?.pkg;
+  if (!type_pkg) {
+    throw new ErrArbitrary(
+      "lacking-capability",
+      `Projecting ${name} from ${Location.type_name(
+        value.type
+      )} is not possible, as it's an intrinsic type. Intrinsic types can only be managed by the Crochet runtime for security.`
+    );
+  }
+
+  if (module.pkg !== type_pkg) {
+    throw new ErrArbitrary(
+      "lacking-capability",
+      `Projecting ${name} from ${Location.type_name(
+        value.type
+      )} is not possible in ${Location.module_location(
+        module
+      )}. Projecting values is only allowed inside of its declaring package---the package must expose commands if it wants fields to be accessible externally.`
+    );
+  }
+}
+
+export function assert_construct_capability(
+  module: CrochetModule,
+  type: CrochetType
+) {
+  const type_pkg = type.module?.pkg;
+  if (!type_pkg) {
+    throw new ErrArbitrary(
+      "lacking-capability",
+      `Constructing ${Location.type_name(
+        type
+      )} is not possible, as it's an intrinsic type. Intrinsic types can only be constructed by the Crochet runtime for security.`
+    );
+  }
+
+  if (module.pkg !== type_pkg) {
+    throw new ErrArbitrary(
+      "lacking-capability",
+      `Constructing ${Location.type_name(
+        type
+      )} is not possible in ${Location.module_location(
+        module
+      )}. Constructing types directly is only allowed inside of its declaring package---the package must expose commands if it wants the type to be constructed externally.`
+    );
+  }
+}

--- a/source/vm/primitives/values.ts
+++ b/source/vm/primitives/values.ts
@@ -299,7 +299,11 @@ export function text_to_string(x: CrochetValue) {
   return x.payload;
 }
 
-export function project(value: CrochetValue, key: string): CrochetValue {
+export function project(
+  value: CrochetValue,
+  key: string,
+  assert_capability: (value: CrochetValue) => void
+): CrochetValue {
   switch (value.tag) {
     case Tag.RECORD: {
       assert_tag(Tag.RECORD, value);
@@ -318,6 +322,7 @@ export function project(value: CrochetValue, key: string): CrochetValue {
 
     case Tag.INSTANCE: {
       assert_tag(Tag.INSTANCE, value);
+      assert_capability(value);
       const index = value.type.layout.get(key);
       if (index == null) {
         throw new ErrArbitrary(
@@ -342,7 +347,9 @@ export function project(value: CrochetValue, key: string): CrochetValue {
 
     case Tag.LIST: {
       assert_tag(Tag.LIST, value);
-      const results = value.payload.map((x) => project(x, key));
+      const results = value.payload.map((x) =>
+        project(x, key, assert_capability)
+      );
       return new CrochetValue(Tag.LIST, value.type, results);
     }
 


### PR DESCRIPTION
This adds the checks for construction and projection capabilities back to Crochet. The rule is that these capabilities are only available for the defining package---but here we run into a problem: intrinsic types have no packages! Still, trusted packages need to manipulate these intrinsic types and provide a view to them.

The temporary solution this PR adds is to skip intrinsic capability checks for trusted packages---but the trusted base for Crochet is too big currently (#24), mostly as a result of native code being unsafe to load right now. This shouldn't be too much of a problem yet because intrinsic types have no real power.

This fixes #14.