### PR TITLE
Introduce trust hierarchies for text

### DIFF
--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -72,7 +72,11 @@ export class ForeignInterface {
   }
 
   text(x: string) {
-    return Values.make_text(this.#universe, x);
+    return Values.make_dynamic_text(this.#universe, x);
+  }
+
+  untrusted_text(x: string) {
+    return Values.make_untrusted_text(this.#universe, x);
   }
 
   box(x: unknown) {

--- a/source/vm/boot.ts
+++ b/source/vm/boot.ts
@@ -142,10 +142,49 @@ export function make_universe() {
     null
   );
 
-  const Text = new CrochetType(null, "text", "", Any, [], [], false, null);
+  const UnsafeArbitraryText = new CrochetType(
+    null,
+    "unsafe-arbitrary-text",
+    "",
+    Any,
+    [],
+    [],
+    false,
+    null
+  );
+  const UntrustedText = new CrochetType(
+    null,
+    "untrusted-text",
+    "",
+    UnsafeArbitraryText,
+    [],
+    [],
+    false,
+    null
+  );
+  const Text = new CrochetType(
+    null,
+    "text",
+    "",
+    UnsafeArbitraryText,
+    [],
+    [],
+    false,
+    null
+  );
   const StaticText = new CrochetType(
     null,
     "static-text",
+    "",
+    Text,
+    [],
+    [],
+    false,
+    null
+  );
+  const DynamicText = new CrochetType(
+    null,
+    "dynamic-text",
     "",
     Text,
     [],
@@ -318,8 +357,14 @@ export function make_universe() {
   world.native_types.define("crochet.core/core.integral", Integral);
   world.native_types.define("crochet.core/core.float", Float);
   world.native_types.define("crochet.core/core.integer", Integer);
+  world.native_types.define(
+    "crochet.core/core.unsafe-arbitrary-text",
+    UnsafeArbitraryText
+  );
+  world.native_types.define("crochet.core/core.untrusted-text", UntrustedText);
   world.native_types.define("crochet.core/core.text", Text);
   world.native_types.define("crochet.core/core.static-text", StaticText);
+  world.native_types.define("crochet.core/core.dynamic-text", DynamicText);
   world.native_types.define("crochet.core/core.interpolation", Interpolation);
   world.native_types.define("crochet.core/core.function", Function);
   for (const f of functions) {
@@ -354,8 +399,11 @@ export function make_universe() {
     False,
     Integer,
     Float,
+    UnsafeArbitraryText,
+    UntrustedText,
     Text,
     StaticText,
+    DynamicText,
     Interpolation,
     Function: functions,
     NativeFunctions: native_lambdas,

--- a/source/vm/intrinsics.ts
+++ b/source/vm/intrinsics.ts
@@ -904,8 +904,11 @@ export class Universe {
       False: CrochetType;
       Integer: CrochetType;
       Float: CrochetType;
+      UnsafeArbitraryText: CrochetType;
+      UntrustedText: CrochetType;
       Text: CrochetType;
       StaticText: CrochetType;
+      DynamicText: CrochetType;
       Interpolation: CrochetType;
       Function: CrochetType[];
       NativeFunctions: CrochetType[];

--- a/source/vm/primitives/dsl.ts
+++ b/source/vm/primitives/dsl.ts
@@ -14,7 +14,7 @@ import {
   make_lambda,
   make_record_from_map,
   make_static_text,
-  make_text,
+  make_dynamic_text,
   make_thunk,
   make_list,
 } from "./values";

--- a/source/vm/primitives/values.ts
+++ b/source/vm/primitives/values.ts
@@ -41,8 +41,12 @@ export function make_float(universe: Universe, x: number) {
   return universe.make_float(x);
 }
 
-export function make_text(universe: Universe, x: string) {
-  return new CrochetValue(Tag.TEXT, universe.types.Text, x);
+export function make_dynamic_text(universe: Universe, x: string) {
+  return new CrochetValue(Tag.TEXT, universe.types.DynamicText, x);
+}
+
+export function make_untrusted_text(universe: Universe, x: string) {
+  return new CrochetValue(Tag.TEXT, universe.types.UntrustedText, x);
 }
 
 export function make_static_text(universe: Universe, x: string) {
@@ -504,7 +508,7 @@ export function from_plain_object(
   if (x == null) {
     return universe.nothing;
   } else if (typeof x === "string") {
-    return make_text(universe, x);
+    return make_dynamic_text(universe, x);
   } else if (typeof x === "bigint") {
     return make_integer(universe, x);
   } else if (typeof x === "number") {

--- a/stdlib/crochet.core/crochet.json
+++ b/stdlib/crochet.core/crochet.json
@@ -91,6 +91,7 @@
     "source/text/equality.crochet",
     "source/text/interpolation.crochet",
     "source/text/views.crochet",
+    "source/text/taint.crochet",
 
     "source/traits/conversion.crochet",
     "source/traits/container.crochet",
@@ -103,6 +104,6 @@
   ],
   "capabilities": {
     "requires": [],
-    "provides": []
+    "provides": ["tainting", "untainting"]
   }
 }

--- a/stdlib/crochet.core/native/text.ts
+++ b/stdlib/crochet.core/native/text.ts
@@ -65,6 +65,22 @@ export default (ffi: ForeignInterface) => {
     return ffi.normalise_interpolation(x);
   });
 
+  ffi.defun("text.make-trusted", (t) => {
+    return ffi.text(ffi.text_to_string(t));
+  });
+
+  ffi.defun("text.make-untrusted", (t) => {
+    return ffi.untrusted_text(ffi.text_to_string(t));
+  });
+
+  ffi.defun("text.untrusted-concat", (l, r) => {
+    return ffi.untrusted_text(ffi.text_to_string(l) + ffi.text_to_string(r));
+  });
+
+  ffi.defun("text.trusted-concat", (l, r) => {
+    return ffi.text(ffi.text_to_string(l) + ffi.text_to_string(r));
+  });
+
   ffi.defun("text.repeat", (x0, n0) => {
     const x = ffi.text_to_string(x0);
     const n = Number(ffi.integer_to_bigint(n0));

--- a/stdlib/crochet.core/source/0-types.crochet
+++ b/stdlib/crochet.core/source/0-types.crochet
@@ -1,5 +1,18 @@
 % crochet
 
+// -- The capabilities
+capability tainting;
+capability untainting;
+
+// -- The tainters
+singleton taint;
+protect global taint with tainting;
+protect type taint with tainting;
+
+singleton untaint;
+protect global untaint with untainting;
+protect type untaint with untainting;
+
 // -- The hierarchy
 
 /// The base of the type hierarchy in Crochet.
@@ -65,12 +78,18 @@ type integer = foreign core.integer;
 
 /// The type of textual values.
 ///
-/// All textual types descend from [text]. And a [text] is always to be
+/// All textual types descend from [unsafe-arbitrary-text]. And it is always to be
 /// considered an opaque blob, only operated on through whatever text
 /// commands are available, and with representation that's entirely up
 /// to the runtime---indeed, the representation may change if the runtime
 /// thinks that's more efficient.
+type unsafe-arbitrary-text = foreign core.unsafe-arbitrary-text;
+
+type untrusted-text = foreign core.untrusted-text;
+
 type text = foreign core.text;
+
+type dynamic-text = foreign core.dynamic-text;
 
 /// The type of text *literals* in source programs.
 ///

--- a/stdlib/crochet.core/source/text/interpolation.crochet
+++ b/stdlib/crochet.core/source/text/interpolation.crochet
@@ -1,7 +1,7 @@
 % crochet
 
 /// Concatenates two pieces of text
-command (X is text) ++ (Y is text) = 
+command (X is unsafe-arbitrary-text) ++ (Y is unsafe-arbitrary-text) = 
   "[X][Y]"
 test
   assert ("" ++ "") flatten-into-plain-text =:= "";
@@ -25,13 +25,13 @@ test
   assert ("[1]a[2]x" ++ "y[3]b[4]") normalise =:= "[1]a[2]xy[3]b[4]";
 end
 
-command (X is text) ++ (Y is interpolation) do
+command (X is unsafe-arbitrary-text) ++ (Y is interpolation) do
   "[X]" ++ Y;
 test
   assert ("abc" ++ "d[1]f") =:= "["abc"]d[1]f";
 end
 
-command (X is interpolation) ++ (Y is text) do
+command (X is interpolation) ++ (Y is unsafe-arbitrary-text) do
   X ++ "[Y]";
 test
   assert ("a[1]c" ++ "def") =:= "a[1]c["def"]";
@@ -66,5 +66,49 @@ test
   assert "[1][2]" static-text =:= "\[_\]\[_\]";
 end
 
-command (X is interpolation) flatten-into-plain-text =
-  foreign interpolation.to-plain-text(X);
+local singleton text-concat;
+
+command (X is interpolation) flatten-into-plain-text do
+  X parts
+    | fold-from: "" with: (text-concat left: _ right: _);
+test
+  // Trusted text begets trusted text
+  let Trusted-A = "A";
+  let Trusted-B = "B";
+  assert "[Trusted-A][Trusted-B]" flatten-into-plain-text === "AB";
+  assert "[Trusted-A][Trusted-B]" flatten-into-plain-text is dynamic-text;
+
+  // Untrusted text begets untrusted text
+  let Untrusted-A = taint make-untrusted: Trusted-A;
+  let Untrusted-B = taint make-untrusted: Trusted-B;
+  assert (untaint make-trusted: "[Trusted-A][Untrusted-B]" flatten-into-plain-text) === "AB";
+  assert "[Trusted-A][Untrusted-B]" flatten-into-plain-text is untrusted-text;
+  assert (untaint make-trusted: "[Untrusted-A][Trusted-B]" flatten-into-plain-text) === "AB";
+  assert "[Untrusted-A][Trusted-B]" flatten-into-plain-text is untrusted-text;
+  assert (untaint make-trusted: "[Untrusted-A][Untrusted-B]" flatten-into-plain-text) === "AB";
+  assert "[Untrusted-A][Untrusted-B]" flatten-into-plain-text is untrusted-text;
+  
+  // Interpolation is flattened recursively
+  let AB = "[Trusted-A][Trusted-B]";
+  let ABAB = "[AB][AB]";
+  let CABABC = "C[ABAB]C";
+  assert CABABC flatten-into-plain-text === "CABABC";
+end
+
+command text-concat left: (L is untrusted-text) right: (R is text) =
+  foreign text.untrusted-concat(L, R);
+
+command text-concat left: (L is text) right: (R is untrusted-text) =
+  foreign text.untrusted-concat(L, R);
+
+command text-concat left: (L is untrusted-text) right: (R is untrusted-text) =
+  foreign text.untrusted-concat(L, R);
+
+command text-concat left: (L is text) right: (R is text) =
+  foreign text.trusted-concat(L, R);
+
+command text-concat left: (L is interpolation) right: R =
+  text-concat left: L flatten-into-plain-text right: R;
+
+command text-concat left: L right: (R is interpolation) =
+  text-concat left: L right: R flatten-into-plain-text;

--- a/stdlib/crochet.core/source/text/taint.crochet
+++ b/stdlib/crochet.core/source/text/taint.crochet
@@ -1,0 +1,14 @@
+% crochet
+
+command taint make-untrusted: (Text is untrusted-text) =
+  Text;
+
+command taint make-untrusted: (Text is text) =
+  foreign text.make-untrusted(Text);
+
+
+command untaint make-trusted: (Text is untrusted-text) =
+  foreign text.make-trusted(Text);
+
+command untaint make-trusted: (Text is text) =
+  Text;

--- a/stdlib/crochet.wrapper.node.file-system/native/fs.ts
+++ b/stdlib/crochet.wrapper.node.file-system/native/fs.ts
@@ -82,7 +82,9 @@ export default (ffi: ForeignInterface) => {
   });
 
   ffi.defun("fs.read-file-text", (path) => {
-    return ffi.text(FS.readFileSync(ffi.text_to_string(path), "utf-8"));
+    return ffi.untrusted_text(
+      FS.readFileSync(ffi.text_to_string(path), "utf-8")
+    );
   });
 
   ffi.defun("fs.real-path", (path) => {

--- a/stdlib/crochet.wrapper.node.http/native/http.ts
+++ b/stdlib/crochet.wrapper.node.http/native/http.ts
@@ -53,7 +53,7 @@ export default (ffi: ForeignInterface) => {
         const chunks: string[] = [];
         res.on("data", (chunk) => chunks.push(chunk));
         res.on("end", () => {
-          result.set("body", ffi.text(chunks.join("")));
+          result.set("body", ffi.untrusted_text(chunks.join("")));
           resolve(
             ffi.record(
               new Map([

--- a/stdlib/crochet.wrapper.node.io/native/terminal.ts
+++ b/stdlib/crochet.wrapper.node.io/native/terminal.ts
@@ -55,7 +55,9 @@ export default (ffi: ForeignInterface) => {
 
   ffi.defmachine("terminal.read-line", function* (prompt0) {
     const prompt = ffi.text_to_string(prompt0);
-    const value = yield ffi.await(readline(prompt).then((x) => ffi.text(x)));
+    const value = yield ffi.await(
+      readline(prompt).then((x) => ffi.untrusted_text(x))
+    );
     return value;
   });
 };

--- a/stdlib/crochet.wrapper.node.os/native/os.ts
+++ b/stdlib/crochet.wrapper.node.os/native/os.ts
@@ -12,14 +12,14 @@ export default (ffi: ForeignInterface) => {
   });
 
   ffi.defun("os.arch", () => {
-    return ffi.text(process.arch);
+    return ffi.untrusted_text(process.arch);
   });
 
   ffi.defun("os.argv", () => {
     const args0 = process.argv.slice(2);
     const split_index = args0.indexOf("--");
     const args = split_index < 0 ? [] : args0.slice(split_index + 1);
-    return ffi.list(args.map((x) => ffi.text(x)));
+    return ffi.list(args.map((x) => ffi.untrusted_text(x)));
   });
 
   ffi.defun("os.chdir", (dir) => {
@@ -28,21 +28,21 @@ export default (ffi: ForeignInterface) => {
   });
 
   ffi.defun("os.cwd", () => {
-    return ffi.text(process.cwd());
+    return ffi.untrusted_text(process.cwd());
   });
 
   ffi.defun("os.env", () => {
     const map = new Map<string, CrochetValue>();
     for (const [k, v] of Object.entries(process.env)) {
       if (v != null) {
-        map.set(k, ffi.text(v));
+        map.set(k, ffi.untrusted_text(v));
       }
     }
     return ffi.record(map);
   });
 
   ffi.defun("os.platform", () => {
-    return ffi.text(process.platform);
+    return ffi.untrusted_text(process.platform);
   });
 
   ffi.defun("os.pid", () => {

--- a/stdlib/crochet.wrapper.node.shell/native/shell.ts
+++ b/stdlib/crochet.wrapper.node.shell/native/shell.ts
@@ -37,6 +37,6 @@ export default (ffi: ForeignInterface) => {
     const options = make_options(ffi.record_to_map(options0));
 
     const result = execFileSync(file, args, options);
-    return ffi.text(result);
+    return ffi.untrusted_text(result);
   });
 };


### PR DESCRIPTION
This patch finally implements the trust hierarchies described in https://robotlolita.me/diary/2021/06/a-tale-of-4-strings/, and which have been on the to-do list for far too long. Libraries in stdlib that interact with the outside world now properly return untrusted-text for the bits of text that cannot be reasonably restricted to known semantics by Crochet. And the only thing one can do with untrusted-text is concatenate it elsewhere.

There'll need to be some more work on the UX of untrusted text in the future, as currently they're just a pain to use and reason about. The Core library now provides two capabilities in the mean time: `tainting` allows access to `taint make-untrusted: X`, which lets untrusted text be constructed from within Crochet code. And `untainting` allows access to `untaint make-trusted: X`, which lets one lift the taint mark in a piece of text, promoting it to a plain `text` type. Parsers currently do not make use of these directly, so a user needs to untaint before parsing---that's an absurd and insecure requirement that will be fixed before the stable release.

Also, more work needs to be done on how trust hierarchies interact with non-textual types. Particularly given how textual types move between structured representations (e.g.: JSON).