### PR TITLE
Introduce rich debug representations

### DIFF
--- a/docs/design/0007-debug-representation.md
+++ b/docs/design/0007-debug-representation.md
@@ -1,0 +1,140 @@
+# [#0007] - Debug Representations
+
+|                  |                    |
+| ---------------- | ------------------ |
+| **Authors**      | Q.                 |
+| **Last updated** | 30th December 2021 |
+| **Status**       | Draft              |
+
+## Summary
+
+In order to properly debug things, we might want to look at values
+from different perspectives to try to understand what's happening.
+Currently the debugging representation just dumps the internals of
+the object, and this is often very unhelpful.
+
+But having the object define a single representation is also often
+unhelpful. This document proposes the idea of "perspectives", which
+allows objects to define multiple (contextual) representations.
+This fits well with multi-methods and can be made trivially
+capability-secure.
+
+## The proposal
+
+The idea behind this proposal consists of a Document language, which
+can describe a (possibly interactive) representation of a value; and
+a Perspective language, which allows describing multiple representations
+securely and in an extensible way (without requiring any coordination).
+
+For example:
+
+    type date-perspective is perspective;
+    type timestamp-perspective is perspective;
+
+    command date-perspective name = "Date";
+    command timestamp-perspective name = "Timestamp";
+
+    command debug-representation for: (X is instant) perspective: date-perspective =
+      self text: (X to-iso8601-text)
+        | typed: #instant;
+
+    command debug-representation for: (X is instant) perspective: timestamp-perspective =
+      self number: (X to-milliseconds-since-unix-epoch)
+        | typed: #instant;
+
+Here the code introduces two new perspective (they're nullary types):
+`date-perspective` and `timestamp-perspective`. The only thing they need
+is to provide a `name` field.
+
+It then proceeds to provide a Document for how the `instant` type can
+be looked at given each of these perspectives. Any other piece of code,
+of course, can define its own perspective types (or reuse other
+perspective types), and then provide debug-representation commands for
+those.
+
+In order to make this work without coordination, it's necessary to
+allow one to find all debug representation branches for a particular
+type, and construct the required perspective types from the branch's
+constraints (hence why they need to be nullary). Because this feature
+is meant for debugging _only_, it can be done in debugging tools with
+minimal support from the VM, and that way it needs not be exposed
+as a regular reflection API.
+
+## Documents
+
+A document is a restricted and declarative language for providing
+representations for a value. It's loosely based on HTML but with
+a simpler layouting system (it requires a flex-box model, however).
+
+The language is as follows:
+
+    number(value: numeric)    -- any number
+    text(value: text)         -- any text
+    boolean(value: boolean)   -- any boolean
+
+    keyword(name: text)       -- highlighted text with no semantics
+    plain-text(content: text) -- text with no semantics
+
+    lazy(description: text, pointer: external-capability)
+
+    list(values: document[])
+    table(header: document[], rows: document[][])
+
+    flow(items: document[])
+    row(items: document[])
+    column(items: document[])
+
+    fixed(width: integer, height: integer, content: document)
+    positioned(position: point2d, anchor: point2d, content: document)
+    padding(top, left, bottom, right)
+    border(top, left, bottom, right)
+
+    circle, triangle, square, line, polygon   (svg shapes)
+
+Documents can be safely serialised as JSON to send to different processes.
+The only constructor that needs a longer explanation is `lazy`. This is
+used to share complex, potentially infinite objects with the outside world,
+and it's done so through an external capability---an unforgeable pointer
+to a Crochet object, which is interacted through RPC (this in turn requires
+some kind of distributed GC).
+
+## Threat model
+
+Debug representations are important for allowing developers to debug
+programs, however it can just as easily be used by attackers to circumvent
+privacy protections. This proposal considers any piece of code included
+in a program to be a potential attacker, so mitigations primarily address that.
+
+Since we treat any piece of code as a potential attacker, that means that
+no piece of code should have access to _read_ the contents of a `document`.
+That makes `document`, as a Crochet type, essentially write-only from the
+program's perspective. It's an opaque blob that you put things in and send
+somewhere for rendering. This keeps the privacy guarantees that regular
+Crochet code has today.
+
+The other problem is with packages adding new perspectives to
+`debug-representation` on types that they don't own. This is already a
+problem in Crochet, and will be handled in terms of static analysis instead.
+The VM will warn you of packages that add commands to types they don't
+own so that you can have more control over it. In this case the problem
+is worsened by debug-representations being ran automatically by the VM
+when serialising a value for representation, however the use of capabilities
+already mitigates the impact of possible attacks (these packages cannot
+elevate their privileges).
+
+Packages can create debug representations that are computationally
+innefficient (on purpose or not). This proposal does not protect against
+that. However, since the only use of this feature is in debugging tools,
+in the playground, a "denial of service" attack at most can be the cause
+of annoyance. The current proposal does not address ways of debugging
+and finding these cases, as it needs to be tackled in a more generalised
+way in a separate proposal.
+
+This proposal does not change anything about who gets a constructing
+capability and can, thus, invoke the debug representations. The proposal
+is to add this to the VM itself, so whoever controls the VM also gets
+the power of generating and reading debug representations. Because we
+avoid any reflection features exposed to Crochet (or native) code,
+this does not add any new ways of doing privilege escalation. The
+command itself also does not receive any powerful capabilities, so
+it's not possible to acquire more privileges from its execution.

--- a/docs/design/0007-debug-representation.md
+++ b/docs/design/0007-debug-representation.md
@@ -74,8 +74,6 @@ The language is as follows:
 
     plain-text(content: text) -- text with no semantics
 
-    lazy(description: text, pointer: external-capability)
-
     list(values: document[])
     table(header: document[], rows: document[][])
 
@@ -95,12 +93,10 @@ The language is as follows:
 > Interactivity is the base of allowing user-defined debugging tools for
 > their own types, however.
 
-Documents can be safely serialised as JSON to send to different processes.
-The only constructor that needs a longer explanation is `lazy`. This is
-used to share complex, potentially infinite objects with the outside world,
-and it's done so through an external capability---an unforgeable pointer
-to a Crochet object, which is interacted through RPC (this in turn requires
-some kind of distributed GC).
+Documents can be safely serialised as JSON to send to different processes,
+and this is an _explicit goal_ of this document language. You should be able
+to pass documents across processes and render them safely, which means that
+you could use this to debug systems remotely as well.
 
 ## Threat model
 

--- a/docs/design/0007-debug-representation.md
+++ b/docs/design/0007-debug-representation.md
@@ -72,7 +72,6 @@ The language is as follows:
     text(value: text)         -- any text
     boolean(value: boolean)   -- any boolean
 
-    keyword(name: text)       -- highlighted text with no semantics
     plain-text(content: text) -- text with no semantics
 
     lazy(description: text, pointer: external-capability)
@@ -86,10 +85,15 @@ The language is as follows:
 
     fixed(width: integer, height: integer, content: document)
     positioned(position: point2d, anchor: point2d, content: document)
-    padding(top, left, bottom, right)
-    border(top, left, bottom, right)
 
     circle, triangle, square, line, polygon   (svg shapes)
+
+> **NOTE:**
+>
+> Future versions of document _will_ include interactivity, but that needs
+> a more well thought-out language because it brings in more threats.
+> Interactivity is the base of allowing user-defined debugging tools for
+> their own types, however.
 
 Documents can be safely serialised as JSON to send to different processes.
 The only constructor that needs a longer explanation is `lazy`. This is

--- a/docs/design/0007-debug-representation.md
+++ b/docs/design/0007-debug-representation.md
@@ -87,7 +87,7 @@ The language is as follows:
 
     group(collapsed: document, expanded: document)
 
-    circle, triangle, square, line, polygon   (svg shapes)
+    circle, ellipse, rectangle, line, polygon, polyline   -- svg shapes
 
 > **NOTE:**
 >

--- a/docs/design/0007-debug-representation.md
+++ b/docs/design/0007-debug-representation.md
@@ -84,6 +84,8 @@ The language is as follows:
     fixed(width: integer, height: integer, content: document)
     positioned(position: point2d, anchor: point2d, content: document)
 
+    group(collapsed: document, expanded: document)
+
     circle, triangle, square, line, polygon   (svg shapes)
 
 > **NOTE:**
@@ -92,6 +94,15 @@ The language is as follows:
 > a more well thought-out language because it brings in more threats.
 > Interactivity is the base of allowing user-defined debugging tools for
 > their own types, however.
+
+The `group` layout is used in a similar fashion to Wadler's idea of layout
+unions in the [A Prettier Printer](https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf)
+paper, but in a slightly simpler and more restricted fashion. One can
+provide a collapsed and an expanded representation, which the renderer
+then decides on based on the current rendering context. This is intended
+as a temporary layout document that should be replaced by a more generic
+one based on goals and constraints in the future---since documents are
+not yet intended to be stored, the risk of doing this is small.
 
 Documents can be safely serialised as JSON to send to different processes,
 and this is an _explicit goal_ of this document language. You should be able

--- a/docs/design/0007-debug-representation.md
+++ b/docs/design/0007-debug-representation.md
@@ -83,7 +83,7 @@ The language is as follows:
     column(items: document[])
 
     fixed(width: integer, height: integer, content: document)
-    positioned(position: point2d, anchor: point2d, content: document)
+    positioned(position: point2d, content: document)
 
     group(collapsed: document, expanded: document)
 

--- a/docs/design/0007-debug-representation.md
+++ b/docs/design/0007-debug-representation.md
@@ -73,6 +73,7 @@ The language is as follows:
     boolean(value: boolean)   -- any boolean
 
     plain-text(content: text) -- text with no semantics
+    code(content: text)       -- text, but monospaced
 
     list(values: document[])
     table(header: document[], rows: document[][])

--- a/source/crochet/crochet.ts
+++ b/source/crochet/crochet.ts
@@ -5,7 +5,15 @@ import * as VM from "../vm";
 import * as Binary from "../binary";
 import { logger } from "../utils/logger";
 import { ForeignInterface } from "./foreign";
-import { CrochetValue, Environment, CrochetTrace, ErrArbitrary } from "../vm";
+import {
+  CrochetValue,
+  Environment,
+  CrochetTrace,
+  ErrArbitrary,
+  debug_perspectives,
+  CrochetType,
+  debug_representations,
+} from "../vm";
 import * as UUID from "uuid";
 
 export type TestReportMessage =
@@ -331,5 +339,16 @@ export class BootedCrochet {
 
   async invoke(name: string, args: CrochetValue[]) {
     return await VM.run_command(this.universe, name, args);
+  }
+
+  async debug_perspectives(value: CrochetValue) {
+    return debug_perspectives(this.universe, value);
+  }
+
+  async debug_representations(
+    value: CrochetValue,
+    perspectives: CrochetType[]
+  ) {
+    return debug_representations(this.universe, value, perspectives);
   }
 }

--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -262,6 +262,10 @@ export class ForeignInterface {
     return Values.to_plain_object(x);
   }
 
+  to_plain_json_native(x: CrochetValue): unknown {
+    return Values.to_plain_json_object(x);
+  }
+
   from_plain_native(x: unknown, trusted: boolean): CrochetValue {
     return Values.from_plain_object(this.#universe, x, trusted);
   }

--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -22,6 +22,7 @@ import {
   run_native,
   run_native_sync,
   Tag,
+  Types,
   Universe,
   Values,
 } from "../vm";
@@ -268,6 +269,28 @@ export class ForeignInterface {
   // == Reflection
   type_name(x: CrochetValue) {
     return Location.type_name(x.type);
+  }
+
+  get_static_type(x: CrochetValue) {
+    return Values.make_static_type(
+      this.#universe,
+      Types.get_static_type(this.#universe, x.type)
+    );
+  }
+
+  get_type_info(x: CrochetValue) {
+    if (x.tag === Tag.TYPE) {
+      Values.assert_tag(Tag.TYPE, x);
+      const type = x.payload;
+      return this.record(
+        new Map([
+          ["name", this.text(type.name)],
+          ["package", this.text(type.module?.pkg.name ?? "crochet.core")],
+        ])
+      );
+    } else {
+      throw this.panic("invalid-type", "Expected a static-type");
+    }
   }
 
   to_debug_string(x: CrochetValue) {

--- a/source/vm/boot.ts
+++ b/source/vm/boot.ts
@@ -245,7 +245,16 @@ export function make_universe() {
   const List = new CrochetType(null, "list", "", Any, [], [], false, null);
   const Enum = new CrochetType(null, "enum", "", Any, [], [], false, null);
   const Cell = new CrochetType(null, "cell", "", Any, [], [], false, null);
-  const Type = new CrochetType(null, "type", "", Any, [], [], false, null);
+  const Type = new CrochetType(
+    null,
+    "static-type",
+    "",
+    Any,
+    [],
+    [],
+    false,
+    null
+  );
   const Effect = new CrochetType(null, "effect", "", null, [], [], false, null);
 
   // Simulations
@@ -345,6 +354,7 @@ export function make_universe() {
     null
   );
 
+  world.native_types.define("crochet.core/core.static-type", Type);
   world.native_types.define("crochet.core/core.any", Any);
   world.native_types.define("crochet.core/core.protected", Protected);
   world.native_types.define("crochet.core/core.unknown", Unknown);

--- a/source/vm/index.ts
+++ b/source/vm/index.ts
@@ -5,3 +5,4 @@ export * from "./primitives";
 export * from "./boot";
 export * from "./evaluation";
 export * from "./run";
+export * from "./representation";

--- a/source/vm/primitives/values.ts
+++ b/source/vm/primitives/values.ts
@@ -501,6 +501,47 @@ export function to_plain_object(x: CrochetValue): unknown {
   }
 }
 
+export function to_plain_json_object(x: CrochetValue): unknown {
+  switch (x.tag) {
+    case Tag.NOTHING:
+      return null;
+
+    case Tag.INTEGER:
+      return x.payload;
+
+    case Tag.FLOAT_64:
+      return x.payload;
+
+    case Tag.TEXT:
+      return x.payload;
+
+    case Tag.TRUE:
+      return true;
+
+    case Tag.FALSE:
+      return false;
+
+    case Tag.LIST:
+      assert_tag(Tag.LIST, x);
+      return x.payload.map((x) => to_plain_json_object(x));
+
+    case Tag.RECORD: {
+      assert_tag(Tag.RECORD, x);
+      const result = Object.create(null);
+      for (const [k, v] of x.payload.entries()) {
+        result[k] = to_plain_json_object(v);
+      }
+      return result;
+    }
+
+    default:
+      throw new ErrArbitrary(
+        `no-conversion-to-native`,
+        `No conversion supported for values of type ${type_name(x.type)}`
+      );
+  }
+}
+
 export function from_plain_object(
   universe: Universe,
   x: unknown,

--- a/source/vm/representation.ts
+++ b/source/vm/representation.ts
@@ -53,7 +53,7 @@ export async function debug_representations(
       {
         name: "Internal",
         document: {
-          tag: "plain-text",
+          tag: "code",
           value: Location.simple_value(value),
         },
       },
@@ -127,7 +127,7 @@ export async function debug_representations(
     {
       name: "Internal",
       document: {
-        tag: "plain-text",
+        tag: "code",
         value: Location.simple_value(value),
       },
     },

--- a/source/vm/representation.ts
+++ b/source/vm/representation.ts
@@ -1,0 +1,135 @@
+import { Types, Values, Location } from "./primitives";
+import { Universe, CrochetValue, CrochetType } from "./intrinsics";
+import { run_command } from "./run";
+
+export function debug_perspectives(universe: Universe, value: CrochetValue) {
+  const type = value.type;
+  const debug_module = universe.world.types.try_lookup_namespaced(
+    "crochet.core",
+    "debug-representation"
+  );
+  const perspective = universe.world.types.try_lookup_namespaced(
+    "crochet.core",
+    "perspective"
+  );
+  const command = universe.world.commands.try_lookup("_ for: _ perspective: _");
+  if (debug_module == null || perspective == null || command == null) {
+    return [];
+  } else {
+    const branches = command.branches.filter((branch) => {
+      return (
+        branch.types[0].type === debug_module &&
+        Types.is_subtype(type, branch.types[1].type) &&
+        Types.is_subtype(branch.types[2].type, perspective)
+      );
+    });
+    return [...new Set(branches.map((branch) => branch.types[2].type))];
+  }
+}
+
+export async function debug_representations(
+  universe: Universe,
+  value: CrochetValue,
+  perspectives0: CrochetType[]
+) {
+  const debug_module = universe.world.definitions.try_lookup_namespaced(
+    "crochet.core",
+    "debug-representation"
+  );
+  const root_perspective = universe.world.types.try_lookup_namespaced(
+    "crochet.core",
+    "perspective"
+  );
+  const debug_serialisation_type = universe.world.types.try_lookup_namespaced(
+    "crochet.core",
+    "debug-serialisation"
+  );
+  if (
+    debug_module == null ||
+    root_perspective == null ||
+    debug_serialisation_type == null
+  ) {
+    return [
+      {
+        name: "Internal",
+        document: {
+          tag: "plain-text",
+          value: Location.simple_value(value),
+        },
+      },
+    ];
+  }
+
+  const debug_serialisation = Values.instantiate(debug_serialisation_type, []);
+
+  const perspectives1 = await Promise.all(
+    perspectives0.map(async (perspective) => {
+      if (!Types.is_subtype(perspective, root_perspective)) {
+        console.warn(
+          `Skipping ${Location.type_name(
+            perspective
+          )} in debug representation: not a perspective`
+        );
+        return null;
+      }
+      if (perspective.fields.length !== 0) {
+        console.warn(
+          `Skipping ${Location.type_name(
+            perspective
+          )} in debug representation: not a nullary type`
+        );
+        return null;
+      }
+
+      const name = await run_command(universe, "_ name", [
+        Values.instantiate(perspective, []),
+      ]);
+      return {
+        name: name,
+        type: perspective,
+        instance: Values.instantiate(perspective, []),
+      };
+    })
+  );
+  const perspectives = perspectives1.filter((x) => x != null).map((x) => x!);
+
+  const repr0 = await Promise.all(
+    perspectives.map(async (perspective) => {
+      try {
+        const doc = await run_command(universe, "_ for: _ perspective: _", [
+          debug_module,
+          value,
+          perspective.instance,
+        ]);
+        const json = await run_command(universe, "_ for: _", [
+          debug_serialisation,
+          doc,
+        ]);
+        return {
+          name: Values.text_to_string(perspective.name),
+          document: Values.to_plain_json_object(json),
+        };
+      } catch (error: any) {
+        console.warn(
+          `Skipping ${Location.type_name(
+            perspective.type
+          )} for debug representation: an error occurred when computing the representation.\n\n${
+            error?.stack ?? error
+          }`
+        );
+        return null;
+      }
+    })
+  );
+
+  return [
+    ...repr0.filter((x) => x !== null).map((x) => x!),
+    {
+      name: "Internal",
+      document: {
+        tag: "plain-text",
+        value: Location.simple_value(value),
+      },
+    },
+  ];
+}

--- a/source/vm/representation.ts
+++ b/source/vm/representation.ts
@@ -81,14 +81,25 @@ export async function debug_representations(
         return null;
       }
 
-      const name = await run_command(universe, "_ name", [
-        Values.instantiate(perspective, []),
-      ]);
-      return {
-        name: name,
-        type: perspective,
-        instance: Values.instantiate(perspective, []),
-      };
+      try {
+        const name = await run_command(universe, "_ name", [
+          Values.instantiate(perspective, []),
+        ]);
+        return {
+          name: name,
+          type: perspective,
+          instance: Values.instantiate(perspective, []),
+        };
+      } catch (error: any) {
+        console.warn(
+          `Skipping ${Location.type_name(
+            perspective
+          )} in debug representation: an error occurred when getting its name.\n\n${
+            error?.stack ?? error
+          }`
+        );
+        return null;
+      }
     })
   );
   const perspectives = perspectives1.filter((x) => x != null).map((x) => x!);

--- a/stdlib/crochet.core/crochet.json
+++ b/stdlib/crochet.core/crochet.json
@@ -61,6 +61,7 @@
     "source/collection/stream.crochet",
 
     "source/debug/constructors.crochet",
+    "source/debug/coercions.crochet",
     "source/debug/perspectives.crochet",
     "source/debug/representations.crochet",
     "source/debug/serialisation.crochet",

--- a/stdlib/crochet.core/crochet.json
+++ b/stdlib/crochet.core/crochet.json
@@ -6,6 +6,7 @@
     "native/floats.js",
     "native/integer.js",
     "native/conversion.js",
+    "native/debug.js",
     "native/list.js",
     "native/record.js",
     "native/cell.js",
@@ -18,6 +19,7 @@
   ],
   "sources": [
     "source/0-types.crochet",
+    "source/debug/types.crochet",
 
     "source/action/action.crochet",
 
@@ -57,6 +59,11 @@
     "source/collection/set.crochet",
     "source/collection/set-algebra.crochet",
     "source/collection/stream.crochet",
+
+    "source/debug/constructors.crochet",
+    "source/debug/perspectives.crochet",
+    "source/debug/representations.crochet",
+    "source/debug/serialisation.crochet",
 
     "source/enum/bounds.crochet",
     "source/enum/enumeration.crochet",

--- a/stdlib/crochet.core/native/debug.ts
+++ b/stdlib/crochet.core/native/debug.ts
@@ -1,0 +1,11 @@
+import type { ForeignInterface } from "../../../build/crochet";
+
+export default (ffi: ForeignInterface) => {
+  ffi.defun("debug.type", (value) => {
+    return ffi.get_static_type(value);
+  });
+
+  ffi.defun("debug.type-info", (value) => {
+    return ffi.get_type_info(value);
+  });
+};

--- a/stdlib/crochet.core/native/debug.ts
+++ b/stdlib/crochet.core/native/debug.ts
@@ -8,4 +8,9 @@ export default (ffi: ForeignInterface) => {
   ffi.defun("debug.type-info", (value) => {
     return ffi.get_type_info(value);
   });
+
+  ffi.defun("debug.to-json", (value) => {
+    const object = ffi.to_plain_json_native(value);
+    return ffi.text(JSON.stringify(object, null, 2));
+  });
 };

--- a/stdlib/crochet.core/source/0-types.crochet
+++ b/stdlib/crochet.core/source/0-types.crochet
@@ -16,6 +16,8 @@ capability untainting;
 /// Allows constructing mutable memory cells.
 capability mutability;
 
+/// Used for internal types.
+capability internal;
 
 // -- The tainters
 
@@ -51,6 +53,8 @@ type unknown = foreign core.unknown;
 /// The type which represents the absense of useful values.
 type nothing = foreign core.nothing;
 
+/// The base type of all static types.
+type static-type = foreign core.static-type;
 
 // -- The logic
 

--- a/stdlib/crochet.core/source/debug/coercions.crochet
+++ b/stdlib/crochet.core/source/debug/coercions.crochet
@@ -1,0 +1,33 @@
+% crochet
+
+implement to-doc-unit for doc-unit;
+
+/// Coerces a Crochet value to a doc-unit
+command doc-unit as doc-unit =
+  self;
+
+implement to-doc-unit for integer;
+/// Coerces an integet to a doc-pixels.
+command integer as doc-unit =
+  new doc-pixels(self);
+
+implement to-doc-unit for float;
+/// Coerces a float to a doc-percent.
+command float as doc-unit =
+  new doc-percent(self);
+
+implement to-doc-unit for nothing;
+/// Coerces a nothing to a doc-unit
+command nothing as doc-unit =
+  doc-unit-unset;
+
+
+/// Constructs a doc-unit from a numeric value.
+command integer as doc-pixels =
+  new doc-pixels(self);
+
+command float as doc-percent =
+  new doc-percent(self);
+
+command float as doc-em =
+  new doc-em(self);

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -26,6 +26,13 @@ command #document plain-text: (X is text) =
 command #document plain-text: (X is interpolation) =
   #document plain-text: (X flatten-into-plain-text);
 
+/// Represents a piece of text with monospaced font.
+command #document code: (X is text) =
+  new doc-code(X);
+
+command #document code: (X is interpolation) =
+  #document plain-text: (X flatten-into-plain-text);
+
 /// Represents a list of values.
 command #document list: (Xs is list<document>) =
   new doc-list(Xs);

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -62,8 +62,8 @@ command #document flex-column: (Xs is list<document>) =
   new doc-flex-column(Xs, doc-unit-unset);
 
 /// Lays items with a fixed layout.
-command #document fixed-layout: (Xs is list<document>) width: (W is doc-unit) height: (H is doc-unit) =
-  new doc-fixed-layout(Xs, W, H);
+command #document fixed-layout: (Xs is list<document>) width: (W has to-doc-unit) height: (H has to-doc-unit) =
+  new doc-fixed-layout(Xs, W as doc-unit, H as doc-unit);
 
 /// Constructs a table from a record of fields.
 command #document fields: (R is record) do
@@ -78,8 +78,52 @@ command #document fields: (R is record) do
 end
 
 /// Constructs a circle shape
-command #document circle-x: (X is doc-unit) y: (Y is doc-unit) radius: (Radius is doc-unit) style: (Style is doc-presentation) =
-  new doc-circle(X, Y, Radius, Style);
+command #document circle =
+  new doc-circle(doc-unit-unset, doc-unit-unset, doc-unit-unset, #document style);
+
+command doc-circle center-x: (X has to-doc-unit) =
+  new doc-circle(X as doc-unit, self.y, self.radius, self.presentation);
+
+command doc-circle center-y: (Y has to-doc-unit) =
+  new doc-circle(self.x, Y as doc-unit, self.radius, self.presentation);
+
+command doc-circle center: (Point is doc-point2d) =
+  new doc-circle(Point.x, Point.y, self.radius, self.presentation);
+
+command doc-circle radius: (Radius has to-doc-unit) =
+  new doc-circle(self.x, self.y, Radius as doc-unit, self.presentation);
+
+command doc-circle style: (Style is doc-presentation) =
+  new doc-circle(self.x, self.y, self.radius, Style);
+
+/// Constructs a rectangle shape
+command #document rectangle =
+  new doc-rectangle(#doc-point2d zero, #doc-dimension zero, #doc-point2d zero, #document style);
+
+command doc-rectangle origin: (Point is doc-point2d) =
+  new doc-rectangle(Point, self.size, self.roundness, self.presentation);
+
+command doc-rectangle size: (Size is doc-dimension) =
+  new doc-rectangle(self.origin, Size, self.roundness, self.presentation);
+
+command doc-rectangle style: (Style is doc-presentation) =
+  new doc-rectangle(self.origin, self.size, self.roundness, Style);
+
+command doc-rectangle width: (Width has to-doc-unit) =
+  new doc-rectangle(self.origin, self.size width: Width as doc-unit, self.roundness, self.presentation);
+
+command doc-rectangle height: (Height has to-doc-unit) =
+  new doc-rectangle(self.origin, self.size height: Height as doc-unit, self.roundness, self.presentation);
+
+command doc-rectangle x: (X has to-doc-unit) =
+  new doc-rectangle(self.origin x: X as doc-unit, self.size, self.roundness, self.presentation);
+
+command doc-rectangle y: (Y has to-doc-unit) =
+  new doc-rectangle(self.origin y: Y as doc-unit, self.size, self.roundness, self.presentation);
+
+command doc-rectangle roundness: (Point is doc-point2d) =
+  new doc-rectangle(self.origin, self.size, Point, self.presentation);
+
 
 /// Represents a typed value.
 command document typed: (Type is static-type) =
@@ -87,12 +131,11 @@ command document typed: (Type is static-type) =
 
 /// Positions a document in a fixed layout.
 command document x: (X is doc-unit) y: (Y is doc-unit) =
-  self position: new doc-point2d(X, Y)
-       anchor: new doc-point2d(doc-unit-unset, doc-unit-unset);
+  self position: new doc-point2d(X, Y);
 
 /// Positions a document in a fixed layout.
-command document position: (Pos is doc-point2d) anchor: (Anchor is doc-point2d) =
-  new doc-position(self, Pos, Anchor);
+command document position: (Pos is doc-point2d) =
+  new doc-position(self, Pos);
 
 /// Provides a compact layout alternative.
 command document compact-layout: (Doc is document) =
@@ -119,18 +162,32 @@ command doc-presentation fill-colour: (Colour is doc-colour) =
 
 command #doc-unit unset = doc-unit-unset;
 
-command integer as doc-pixels =
-  new doc-pixels(self);
 
-command float as doc-percent =
-  new doc-percent(self);
+command #doc-point2d zero =
+  new doc-point2d(new doc-pixels(0), new doc-pixels(0));
 
-command float as doc-em =
-  new doc-em(self);
+command #doc-point2d x: (X has to-doc-unit) y: (Y has to-doc-unit) =
+  new doc-point2d(X as doc-unit, Y as doc-unit);
+
+command doc-point2d x: (X has to-doc-unit) =
+  new doc-point2d(X as doc-unit, self.y);
+
+command doc-point2d y: (Y has to-doc-unit) =
+  new doc-point2d(self.x, Y as doc-unit);
 
 
-command #doc-point2d x: (X is doc-unit) y: (Y is doc-unit) =
-  new doc-point2d(X, Y);
+command #doc-dimension zero =
+  new doc-dimension(new doc-pixels(0), new doc-pixels(0));
+
+command #doc-dimension width: (W has to-doc-unit) height: (H has to-doc-unit) =
+  new doc-dimension(W as doc-unit, H as doc-unit);
+
+command doc-dimension width: (W has to-doc-unit) =
+  new doc-dimension(W as doc-unit, self.height);
+
+command doc-dimension height: (H has to-doc-unit) =
+  new doc-dimension(self.width, H as doc-unit);
+
 
 command #doc-colour transparent =
   doc-colour-transparent;

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -145,6 +145,21 @@ command doc-line to: (Point is doc-point2d) =
 command doc-line style: (Style is doc-presentation) =
   new doc-line(self.from, self.to, Style);
 
+/// Constructs a polygon shape
+command #document polygon: (Points is list<point2d>) =
+  new doc-polygon(Points, #document style);
+
+command doc-polygon style: (Style is doc-presentation) =
+  new doc-polygon(self.points, Style);
+
+/// Constructs a polyline shape
+command #document polyline: (Points is list<point2d>) =
+  new doc-polyline(Points, #document style);
+
+command doc-polyline style: (Style is doc-presentation) =
+  new doc-polyline(self.points, Style);
+
+
 /// Represents a typed value.
 command document typed: (Type is static-type) =
   new doc-typed(self, Type);

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -104,7 +104,6 @@ command doc-ellipse radius: (Radius is doc-point2d) =
 command doc-ellipse style: (Style is doc-presentation) =
   new doc-ellipse(self.center, self.radius, Style);
 
-
 /// Constructs a rectangle shape
 command #document rectangle =
   new doc-rectangle(#doc-point2d zero, #doc-dimension zero, #doc-point2d zero, #document style);
@@ -133,6 +132,18 @@ command doc-rectangle y: (Y has to-doc-unit) =
 command doc-rectangle roundness: (Point is doc-point2d) =
   new doc-rectangle(self.origin, self.size, Point, self.presentation);
 
+/// Constructs a line shape
+command #document line =
+  new doc-line(#doc-point2d zero, #doc-point2d zero, #document style);
+
+command doc-line from: (Point is doc-point2d) =
+  new doc-line(Point, self.to, self.presentation);
+
+command doc-line to: (Point is doc-point2d) =
+  new doc-line(self.from, Point, self.presentation);
+
+command doc-line style: (Style is doc-presentation) =
+  new doc-line(self.from, self.to, Style);
 
 /// Represents a typed value.
 command document typed: (Type is static-type) =

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -30,7 +30,7 @@ command #document list: (Xs is list<document>) =
 /// Represents a table of values.
 command #document table-header: (Hs is list<document>) rows: (Rs is list<doc-table-row>)
 requires
-  consistent-layout :: Rs all-true: { R in R.cells count === Hs count }
+  consistent-layout :: Rs all: { R in R.cells count === Hs count }
 do
   new doc-table(Hs, Rs);
 end

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -23,6 +23,9 @@ command #document boolean: (X is boolean) =
 command #document plain-text: (X is text) =
   new doc-plain-text(X);
 
+command #document plain-text: (X is interpolation) =
+  #document plain-text: (X flatten-into-plain-text);
+
 /// Represents a list of values.
 command #document list: (Xs is list<document>) =
   new doc-list(Xs);
@@ -61,7 +64,10 @@ command #document fields: (R is record) do
                | map: { P in #document table-row: [#document plain-text: P key, P value] };
   #document
     | table-header: [#document plain-text: "Field", #document plain-text: "Value"]
-      rows: Rows;
+      rows: Rows
+    | compact-layout: (
+        #document plain-text: "([Rows count to-text] fields)"
+      );
 end
 
 /// Represents a typed value.
@@ -77,3 +83,11 @@ command document x: (X is doc-unit) y: (Y is doc-unit) =
 /// Positions a document in a fixed layout.
 command document position: (Pos is doc-point2d) anchor: (Anchor is doc-point2d) =
   new doc-position(self, Pos, Anchor);
+
+/// Provides a compact layout alternative.
+command document compact-layout: (Doc is document) =
+  new doc-group(Doc, self);
+
+/// Provides an expanded layout alternative.
+command document expanded-layout: (Doc is document) =
+  new doc-group(self, Doc);

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -1,0 +1,79 @@
+% crochet
+
+/// Represents nothing
+command #document empty =
+  doc-empty;
+
+/// Represents any number
+command #document number: (X is numeric) =
+  new doc-number(X)
+    | typed: (foreign debug.type(X));
+
+/// Represents any crochet text (and _highlights_ that it is a Crochet text,
+/// e.g.: by having quotes around it).
+command #document crochet-text: (X is unsafe-arbitrary-text) =
+  new doc-text(X);
+
+/// Represents any boolean.
+command #document boolean: (X is boolean) =
+  new doc-boolean(X);
+
+
+/// Represents a piece of text with no semantics.
+command #document plain-text: (X is text) =
+  new doc-plain-text(X);
+
+/// Represents a list of values.
+command #document list: (Xs is list<document>) =
+  new doc-list(Xs);
+
+/// Represents a table of values.
+command #document table-header: (Hs is list<document>) rows: (Rs is list<doc-table-row>)
+requires
+  consistent-layout :: Rs all-true: { R in R.cells count === Hs count }
+do
+  new doc-table(Hs, Rs);
+end
+
+/// Represents a row in a table.
+command #document table-row: (Cells is list<document>) =
+  new doc-table-row(Cells);
+
+/// Lays items with flow layouting.
+command #document flow: (Xs is list<document>) =
+  new doc-flow(Xs);
+
+/// Lays items with a flex row.
+command #document flex-row: (Xs is list<document>) =
+  new doc-flex-row(Xs, doc-unit-unset);
+
+/// Lays items with a flex column.
+command #document flex-column: (Xs is list<document>) =
+  new doc-flex-column(Xs, doc-unit-unset);
+
+/// Lays items with a fixed layout.
+command #document fixed-layout: (Xs is list<document>) width: (W is doc-unit) height: (H is doc-unit) =
+  new doc-fixed-layout(Xs, W, H);
+
+/// Constructs a table from a record of fields.
+command #document fields: (R is record) do
+  let Rows = R pairs
+               | map: { P in #document table-row: [#document plain-text: P key, P value] };
+  #document
+    | table-header: [#document plain-text: "Field", #document plain-text: "Value"]
+      rows: Rows;
+end
+
+/// Represents a typed value.
+command document typed: (Type is static-type) =
+  new doc-typed(self, Type);
+
+
+/// Positions a document in a fixed layout.
+command document x: (X is doc-unit) y: (Y is doc-unit) =
+  self position: new doc-point2d(X, Y)
+       anchor: new doc-point2d(doc-unit-unset, doc-unit-unset);
+
+/// Positions a document in a fixed layout.
+command document position: (Pos is doc-point2d) anchor: (Anchor is doc-point2d) =
+  new doc-position(self, Pos, Anchor);

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -77,10 +77,13 @@ command #document fields: (R is record) do
       );
 end
 
+/// Constructs a circle shape
+command #document circle-x: (X is doc-unit) y: (Y is doc-unit) radius: (Radius is doc-unit) style: (Style is doc-presentation) =
+  new doc-circle(X, Y, Radius, Style);
+
 /// Represents a typed value.
 command document typed: (Type is static-type) =
   new doc-typed(self, Type);
-
 
 /// Positions a document in a fixed layout.
 command document x: (X is doc-unit) y: (Y is doc-unit) =
@@ -98,3 +101,46 @@ command document compact-layout: (Doc is document) =
 /// Provides an expanded layout alternative.
 command document expanded-layout: (Doc is document) =
   new doc-group(self, Doc);
+
+
+// -- Styles
+command #document style =
+  new doc-presentation(doc-colour-transparent, doc-unit-unset, doc-colour-transparent);
+
+command doc-presentation stroke-colour: (Colour is doc-colour) =
+  new doc-presentation(Colour, self.stroke-width, self.fill-colour);
+
+command doc-presentation stroke-width: (Width is doc-unit) =
+  new doc-presentation(self.stroke-colour, Width, self.fill-colour);
+
+command doc-presentation fill-colour: (Colour is doc-colour) =
+  new doc-presentation(self.stroke-colour, self.stroke-width, Colour);
+
+
+command #doc-unit unset = doc-unit-unset;
+
+command integer as doc-pixels =
+  new doc-pixels(self);
+
+command float as doc-percent =
+  new doc-percent(self);
+
+command float as doc-em =
+  new doc-em(self);
+
+
+command #doc-point2d x: (X is doc-unit) y: (Y is doc-unit) =
+  new doc-point2d(X, Y);
+
+command #doc-colour transparent =
+  doc-colour-transparent;
+
+command #doc-colour red: (R is integer) green: (G is integer) blue: (B is integer) alpha: (A is integer)
+requires
+  byte-red :: (R >= 0) and (R <= 255),
+  byte-green :: (G >= 0) and (G <= 255),
+  byte-blue :: (B >= 0) and (B <= 255),
+  byte-alpha :: (A >= 0) and (A <= 255)
+do
+  new doc-colour-rgba(R, G, B, A);
+end

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -188,8 +188,8 @@ command #document style =
 command doc-presentation stroke-colour: (Colour is doc-colour) =
   new doc-presentation(Colour, self.stroke-width, self.fill-colour);
 
-command doc-presentation stroke-width: (Width is doc-unit) =
-  new doc-presentation(self.stroke-colour, Width, self.fill-colour);
+command doc-presentation stroke-width: (Width has to-doc-unit) =
+  new doc-presentation(self.stroke-colour, Width as doc-unit, self.fill-colour);
 
 command doc-presentation fill-colour: (Colour is doc-colour) =
   new doc-presentation(self.stroke-colour, self.stroke-width, Colour);

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -79,22 +79,31 @@ end
 
 /// Constructs a circle shape
 command #document circle =
-  new doc-circle(doc-unit-unset, doc-unit-unset, doc-unit-unset, #document style);
-
-command doc-circle center-x: (X has to-doc-unit) =
-  new doc-circle(X as doc-unit, self.y, self.radius, self.presentation);
-
-command doc-circle center-y: (Y has to-doc-unit) =
-  new doc-circle(self.x, Y as doc-unit, self.radius, self.presentation);
+  new doc-circle(#doc-point2d zero, doc-unit-unset, #document style);
 
 command doc-circle center: (Point is doc-point2d) =
-  new doc-circle(Point.x, Point.y, self.radius, self.presentation);
+  new doc-circle(Point, self.radius, self.presentation);
 
 command doc-circle radius: (Radius has to-doc-unit) =
-  new doc-circle(self.x, self.y, Radius as doc-unit, self.presentation);
+  new doc-circle(self.center, Radius as doc-unit, self.presentation);
 
 command doc-circle style: (Style is doc-presentation) =
-  new doc-circle(self.x, self.y, self.radius, Style);
+  new doc-circle(self.center, self.radius, Style);
+
+
+/// Constructs an ellipse
+command #document ellipse =
+  new doc-ellipse(#doc-point2d zero, #doc-point2d zero, #document style);
+
+command doc-ellipse center: (Point is doc-point2d) =
+  new doc-ellipse(Point, self.radius, self.presentation);
+
+command doc-ellipse radius: (Radius is doc-point2d) =
+  new doc-ellipse(self.center, Radius, self.presentation);
+
+command doc-ellipse style: (Style is doc-presentation) =
+  new doc-ellipse(self.center, self.radius, Style);
+
 
 /// Constructs a rectangle shape
 command #document rectangle =
@@ -130,8 +139,8 @@ command document typed: (Type is static-type) =
   new doc-typed(self, Type);
 
 /// Positions a document in a fixed layout.
-command document x: (X is doc-unit) y: (Y is doc-unit) =
-  self position: new doc-point2d(X, Y);
+command document x: (X has doc-unit) y: (Y has doc-unit) =
+  self position: new doc-point2d(X as doc-unit, Y as doc-unit);
 
 /// Positions a document in a fixed layout.
 command document position: (Pos is doc-point2d) =

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -165,8 +165,8 @@ command document typed: (Type is static-type) =
   new doc-typed(self, Type);
 
 /// Positions a document in a fixed layout.
-command document x: (X has doc-unit) y: (Y has doc-unit) =
-  self position: new doc-point2d(X as doc-unit, Y as doc-unit);
+command document x: (X has to-doc-unit) y: (Y has to-doc-unit) =
+  self position: (#doc-point2d x: X y: Y);
 
 /// Positions a document in a fixed layout.
 command document position: (Pos is doc-point2d) =

--- a/stdlib/crochet.core/source/debug/perspectives.crochet
+++ b/stdlib/crochet.core/source/debug/perspectives.crochet
@@ -1,0 +1,6 @@
+% crochet
+
+implement debug-perspective for default-perspective;
+
+/// The name of the perspective.
+command default-perspective name = "Default";

--- a/stdlib/crochet.core/source/debug/perspectives.crochet
+++ b/stdlib/crochet.core/source/debug/perspectives.crochet
@@ -1,6 +1,9 @@
 % crochet
 
 implement debug-perspective for default-perspective;
+implement debug-perspective for source-perspective;
 
 /// The name of the perspective.
 command default-perspective name = "Default";
+
+command source-perspective name = "Source code";

--- a/stdlib/crochet.core/source/debug/representations.crochet
+++ b/stdlib/crochet.core/source/debug/representations.crochet
@@ -8,6 +8,9 @@ command debug-representation for: X =
 command debug-representation for: X perspective: default-perspective =
   #document empty typed: (foreign debug.type(X));
 
+command debug-representation for: (X is document) perspective: default-perspective =
+  X;
+
 command debug-representation for: (X is boolean) perspective: default-perspective =
   #document boolean: X;
 
@@ -125,3 +128,12 @@ command debug-representation for: (X is association) perspective: default-perspe
     | typed: #association;
 end
 
+/// Source code perspectives for documents
+command debug-representation for: (X is document) perspective: source-perspective do
+  let Serialisation = new debug-serialisation;
+  let JSON = Serialisation for: X;
+
+  #document
+    | code: (foreign debug.to-json(JSON))
+    | typed: (foreign debug.type(X))
+end

--- a/stdlib/crochet.core/source/debug/representations.crochet
+++ b/stdlib/crochet.core/source/debug/representations.crochet
@@ -31,17 +31,26 @@ command debug-representation for: (X is record) perspective: default-perspective
   #document
     | table-header: [#document plain-text: "Key", #document plain-text: "Value"]
       rows: Rows
-    | typed: #record;
+    | typed: #record
+    | compact-layout: (
+        #document plain-text: "(record with [Rows count to-text] keys)"
+      );
 end
 
 command debug-representation for: (X is list) perspective: default-perspective do
   #document list: (X map: (self for: _ perspective: default-perspective))
-    | typed: #list;
+    | typed: #list
+    | compact-layout: (
+        #document plain-text: "(list with [X count to-text] elements)"
+      );
 end
 
 command debug-representation for: (X is set) perspective: default-perspective do
   #document list: (X map: (self for: _ perspective: default-perspective))
-    | typed: #set;
+    | typed: #set
+    | compact-layout: (
+        #document plain-text: "(set with [X count to-text] elements)"
+      );
 end
 
 command debug-representation for: (X is map) perspective: default-perspective do
@@ -54,7 +63,10 @@ command debug-representation for: (X is map) perspective: default-perspective do
   #document
     | table-header: [#document plain-text: "Key", #document plain-text: "Value"]
       rows: Rows
-    | typed: #map;
+    | typed: #map
+    | compact-layout: (
+        #document plain-text: "(map with [Rows count to-text] pairs)"
+      );
 end
 
 command debug-representation for: (X is ok) perspective: default-perspective do

--- a/stdlib/crochet.core/source/debug/representations.crochet
+++ b/stdlib/crochet.core/source/debug/representations.crochet
@@ -1,0 +1,115 @@
+% crochet
+
+/// Default debug representation.
+command debug-representation for: X =
+  self for: X perspective: default-perspective;
+
+/// Default debug representation.
+command debug-representation for: X perspective: default-perspective =
+  #document empty typed: (foreign debug.type(X));
+
+command debug-representation for: (X is boolean) perspective: default-perspective =
+  #document boolean: X;
+
+command debug-representation for: (X is numeric) perspective: default-perspective =
+  #document number: X;
+
+command debug-representation for: (X is unsafe-arbitrary-text) perspective: default-perspective =
+  #document crochet-text: X;
+
+command debug-representation for: (X is interpolation) perspective: default-perspective =
+  #document flow: (X parts map: (self for: _ perspective: default-perspective))
+    | typed: #interpolation;
+
+command debug-representation for: (X is record) perspective: default-perspective do
+  let Rows = X pairs
+              | map: { P in #document table-row: [
+                              self for: P key perspective: default-perspective,
+                              self for: P value perspective: default-perspective,
+                            ]
+                     };
+  #document
+    | table-header: [#document plain-text: "Key", #document plain-text: "Value"]
+      rows: Rows
+    | typed: #record;
+end
+
+command debug-representation for: (X is list) perspective: default-perspective do
+  #document list: (X map: (self for: _ perspective: default-perspective))
+    | typed: #list;
+end
+
+command debug-representation for: (X is set) perspective: default-perspective do
+  #document list: (X map: (self for: _ perspective: default-perspective))
+    | typed: #set;
+end
+
+command debug-representation for: (X is map) perspective: default-perspective do
+  let Rows = X pairs
+              | map: { P in #document table-row: [
+                              self for: P key perspective: default-perspective,
+                              self for: P value perspective: default-perspective,
+                            ]
+                     };
+  #document
+    | table-header: [#document plain-text: "Key", #document plain-text: "Value"]
+      rows: Rows
+    | typed: #map;
+end
+
+command debug-representation for: (X is ok) perspective: default-perspective do
+  self for: X value perspective: default-perspective
+    | typed: #ok;
+end
+
+command debug-representation for: (X is error) perspective: default-perspective do
+  self for: X reason perspective: default-perspective
+    | typed: #error;
+end
+
+command debug-representation for: (X is cell) perspective: default-perspective do
+  self for: X value perspective: default-perspective
+    | typed: #cell;
+end
+
+command debug-representation for: (X is read-only-cell) perspective: default-perspective do
+  self for: X.cell value perspective: default-perspective
+    | typed: #read-only-cell;
+end
+
+command debug-representation for: (X is zip-pair) perspective: default-perspective do
+  #document
+    | fields: [
+        first -> self for: X first perspective: default-perspective,
+        second -> self for: X second perspective: default-perspective,
+      ]
+    | typed: #zip-pair;
+end
+
+command debug-representation for: (X is partition-pair) perspective: default-perspective do
+  #document
+    | fields: [
+        satisfying -> self for: X satisfying perspective: default-perspective,
+        not-satisfying -> self for: X not-satisfying perspective: default-perspective,
+      ]
+    | typed: #partition-pair;
+end
+
+command debug-representation for: (X is indexed) perspective: default-perspective do
+  #document
+    | fields: [
+        index -> self for: X index perspective: default-perspective,
+        value -> self for: X value perspective: default-perspective,
+      ]
+    | typed: #indexed;
+end
+
+command debug-representation for: (X is association) perspective: default-perspective do
+  #document
+    | fields: [
+        key -> self for: X key perspective: default-perspective,
+        value -> self for: X value perspective: default-perspective,
+      ]
+    | typed: #association;
+end
+

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -9,7 +9,7 @@ command debug-serialisation for: doc-empty =
 command debug-serialisation for: (X is doc-number) =
   [
     tag -> "number",
-    value -> X.value,
+    value -> X.value to-text,
   ];
 
 command debug-serialisation for: (X is doc-text) =
@@ -22,7 +22,7 @@ command debug-serialisation for: (X is doc-text) =
 command debug-serialisation for: (X is doc-boolean) =
   [
     tag -> "boolean",
-    value -> X.value,
+    value -> X.value to,
   ];
 
 command debug-serialisation for: (X is doc-plain-text) =
@@ -78,7 +78,7 @@ command debug-serialisation for: (X is doc-fixed-layout) =
 command debug-serialisation for: (X is doc-position) =
   [
     tag -> "position",
-    items -> X.items map: (self for: _),
+    content -> self for: X.content,
     position -> self for: X.position,
     anchor -> self for: X.position,
   ];

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -93,6 +93,14 @@ command debug-serialisation for: (X is doc-typed) do
   ];
 end
 
+command debug-serialisation for: (X is doc-group) do
+  [
+    tag -> "group",
+    compact -> self for: X.compact,
+    expanded -> self for: X.expanded,
+  ];
+end
+
 
 // -- Units
 command debug-serialisation for: (X is doc-point2d) =

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -136,7 +136,7 @@ end
 command debug-serialisation for: (X is doc-polygon) do
   [
     tag -> "polygon",
-    points -> (self.points map: (self for: _)),
+    points -> (X.points map: (self for: _)),
     presentation -> self for: X.presentation,
   ];
 end
@@ -144,7 +144,7 @@ end
 command debug-serialisation for: (X is doc-polyline) do
   [
     tag -> "polyline",
-    points -> (self.points map: (self for: _)),
+    points -> (X.points map: (self for: _)),
     presentation -> self for: X.presentation,
   ];
 end

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -31,6 +31,12 @@ command debug-serialisation for: (X is doc-plain-text) =
     value -> X.value,
   ];
 
+command debug-serialisation for: (X is doc-code) =
+  [
+    tag -> "code",
+    value -> X.value,
+  ];
+
 command debug-serialisation for: (X is doc-list) =
   [
     tag -> "list",

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -77,16 +77,15 @@ command debug-serialisation for: (X is doc-fixed-layout) =
   [
     tag -> "fixed-layout",
     items -> X.items map: (self for: _),
-    width -> self for: X.gap,
-    height -> self for: X.gap,
+    width -> self for: X.width,
+    height -> self for: X.height,
   ];
 
 command debug-serialisation for: (X is doc-position) =
   [
     tag -> "position",
     content -> self for: X.content,
-    position -> self for: X.position,
-    anchor -> self for: X.position,
+    position -> self for: X.position
   ];
 
 command debug-serialisation for: (X is doc-typed) do
@@ -117,12 +116,29 @@ command debug-serialisation for: (X is doc-circle) do
   ];
 end
 
+command debug-serialisation for: (X is doc-rectangle) do
+  [
+    tag -> "rectangle",
+    origin -> self for: X.origin,
+    size -> self for: X.size,
+    roundness -> self for: X.roundness,
+    presentation -> self for: X.presentation,
+  ]
+end
+
 // -- Units
 command debug-serialisation for: (X is doc-point2d) =
   [
     tag -> "point-2d",
     x -> self for: X.x,
     y -> self for: X.y,
+  ];
+
+command debug-serialisation for: (X is doc-dimension) =
+  [
+    tag -> "dimension",
+    width -> self for: X.width,
+    height -> self for: X.height
   ];
 
 command debug-serialisation for: (X is doc-em) =

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -109,10 +109,18 @@ end
 command debug-serialisation for: (X is doc-circle) do
   [
     tag -> "circle",
-    x -> self for: X.x,
-    y -> self for: X.y,
+    center -> self for: X.center,
     radius -> self for: X.radius,
     presentation -> self for: X.presentation,
+  ];
+end
+
+command debug-serialisation for: (X is doc-ellipse) do
+  [
+    tag -> "ellipse",
+    center -> self for: X.center,
+    radius -> self for: X.radius,
+    presentation -> self for: X.presentation
   ];
 end
 

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -1,0 +1,123 @@
+% crochet
+
+/// Serialises a document to a JSON-friendly format.
+command debug-serialisation for: doc-empty =
+  [
+    tag -> "empty"
+  ];
+
+command debug-serialisation for: (X is doc-number) =
+  [
+    tag -> "number",
+    value -> X.value,
+  ];
+
+command debug-serialisation for: (X is doc-text) =
+  [
+    tag -> "text",
+    value -> X.value,
+    untrusted -> X.value is untrusted-text,
+  ];
+
+command debug-serialisation for: (X is doc-boolean) =
+  [
+    tag -> "boolean",
+    value -> X.value,
+  ];
+
+command debug-serialisation for: (X is doc-plain-text) =
+  [
+    tag -> "plain-text",
+    value -> X.value,
+  ];
+
+command debug-serialisation for: (X is doc-list) =
+  [
+    tag -> "list",
+    items -> X.items map: (self for: _),
+  ];
+
+command debug-serialisation for: (X is doc-table) =
+  [
+    tag -> "table",
+    header -> X.header map: (self for: _),
+    rows -> X.rows map: (self for: _),
+  ];
+
+command debug-serialisation for: (X is doc-table-row) =
+  X.cells map: (self for: _);
+
+command debug-serialisation for: (X is doc-flow) =
+  [
+    tag -> "flow",
+    items -> X.items map: (self for: _),
+  ];
+
+command debug-serialisation for: (X is doc-flex-row) =
+  [
+    tag -> "flex-row",
+    items -> X.items map: (self for: _),
+    gap -> self for: X.gap,
+  ];
+
+command debug-serialisation for: (X is doc-flex-column) =
+  [
+    tag -> "flex-column",
+    items -> X.items map: (self for: _),
+    gap -> self for: X.gap,
+  ];
+
+command debug-serialisation for: (X is doc-fixed-layout) =
+  [
+    tag -> "fixed-layout",
+    items -> X.items map: (self for: _),
+    width -> self for: X.gap,
+    height -> self for: X.gap,
+  ];
+
+command debug-serialisation for: (X is doc-position) =
+  [
+    tag -> "position",
+    items -> X.items map: (self for: _),
+    position -> self for: X.position,
+    anchor -> self for: X.position,
+  ];
+
+command debug-serialisation for: (X is doc-typed) do
+  let Info = foreign debug.type-info(X.crochet-type);
+  [
+    tag -> "typed",
+    content -> self for: X.content,
+    type-name -> Info.name,
+    package-name -> Info.package,
+  ];
+end
+
+
+// -- Units
+command debug-serialisation for: (X is doc-point2d) =
+  [
+    x -> self for: X.x,
+    y -> self for: X.y,
+  ];
+
+command debug-serialisation for: (X is doc-em) =
+  [
+    unit -> "em",
+    value -> X.value,
+  ];
+
+command debug-serialisation for: (X is doc-percent) =
+  [
+    unit -> "percent",
+    value -> X.value,
+  ];
+
+command debug-serialisation for: (X is doc-pixels) =
+  [
+    unit -> "pixel",
+    value -> X.value,
+  ];
+
+command debug-serialisation for: doc-unit-unset =
+  nothing;

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -133,6 +133,22 @@ command debug-serialisation for: (X is doc-line) do
   ];
 end
 
+command debug-serialisation for: (X is doc-polygon) do
+  [
+    tag -> "polygon",
+    points -> (self.points map: (self for: _)),
+    presentation -> self for: X.presentation,
+  ];
+end
+
+command debug-serialisation for: (X is doc-polyline) do
+  [
+    tag -> "polyline",
+    points -> (self.points map: (self for: _)),
+    presentation -> self for: X.presentation,
+  ];
+end
+
 command debug-serialisation for: (X is doc-rectangle) do
   [
     tag -> "rectangle",

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -120,7 +120,16 @@ command debug-serialisation for: (X is doc-ellipse) do
     tag -> "ellipse",
     center -> self for: X.center,
     radius -> self for: X.radius,
-    presentation -> self for: X.presentation
+    presentation -> self for: X.presentation,
+  ];
+end
+
+command debug-serialisation for: (X is doc-line) do
+  [
+    tag -> "line",
+    from -> self for: X.from,
+    to -> self for: X.to,
+    presentation -> self for: X.presentation,
   ];
 end
 

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -107,10 +107,20 @@ command debug-serialisation for: (X is doc-group) do
   ];
 end
 
+command debug-serialisation for: (X is doc-circle) do
+  [
+    tag -> "circle",
+    x -> self for: X.x,
+    y -> self for: X.y,
+    radius -> self for: X.radius,
+    presentation -> self for: X.presentation,
+  ];
+end
 
 // -- Units
 command debug-serialisation for: (X is doc-point2d) =
   [
+    tag -> "point-2d",
     x -> self for: X.x,
     y -> self for: X.y,
   ];
@@ -130,8 +140,32 @@ command debug-serialisation for: (X is doc-percent) =
 command debug-serialisation for: (X is doc-pixels) =
   [
     unit -> "pixel",
-    value -> X.value,
+    value -> X.value as float,
   ];
 
 command debug-serialisation for: doc-unit-unset =
   nothing;
+
+
+// -- Presentation
+command debug-serialisation for: (X is doc-presentation) =
+  [
+    tag -> "presentation",
+    stroke-colour -> self for: X.stroke-colour,
+    stroke-width -> self for: X.stroke-width,
+    fill-colour -> self for: X.fill-colour,
+  ];
+
+
+// -- Colours
+command debug-serialisation for: doc-colour-transparent =
+  nothing;
+
+command debug-serialisation for: (X is doc-colour-rgba) =
+  [
+    tag -> "rgba",
+    red -> X.red as float,
+    green -> X.green as float,
+    blue -> X.blue as float,
+    alpha -> X.alpha as float,
+  ];

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -156,3 +156,6 @@ type doc-rectangle(origin is doc-point2d, size is doc-dimension, roundness is do
 
 /// An ellipse shape
 type doc-ellipse(center is doc-point2d, radius is doc-point2d, presentation is doc-presentation) is document;
+
+/// A line shape
+type doc-line(from is doc-point2d, to is doc-point2d, presentation is doc-presentation) is document;

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -65,6 +65,13 @@ type doc-em(value is float) is doc-unit;
 /// A 2d point of doc units.
 type doc-point2d(x is doc-unit, y is doc-unit);
 
+/// A dimension of doc units.
+type doc-dimension(width is doc-unit, height is doc-unit);
+
+/// The trait of everything that can be made into a doc-unit implicitly
+trait to-doc-unit with
+  command Type as doc-unit -> doc-unit;
+end
 
 /// The base type of all colours used by documents.
 abstract doc-colour;
@@ -132,7 +139,7 @@ type doc-flex-column(items is list<document>, gap is doc-unit) is document;
 type doc-fixed-layout(items is list<document>, width is doc-unit, height is doc-unit) is document;
 
 /// Positions the item inside of a fixed layout container
-type doc-position(content is document, position is doc-point2d, anchor is doc-point2d) is document;
+type doc-position(content is document, position is doc-point2d) is document;
 
 /// Marks a document as belonging to a specific type
 type doc-typed(content is document, crochet-type is static-type) is document;
@@ -143,3 +150,7 @@ type doc-group(compact is document, expanded is document) is document;
 
 /// A circle shape
 type doc-circle(x is doc-unit, y is doc-unit, radius is doc-unit, presentation is doc-presentation) is document;
+
+/// A rectangle shape
+type doc-rectangle(origin is doc-point2d, size is doc-dimension, roundness is doc-point2d, presentation is doc-presentation) is document;
+

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -12,9 +12,7 @@
 singleton debug-representation;
 
 /// Used for serialisation. No powers are granted for external modules.
-singleton debug-serialisation;
-protect global debug-serialisation with internal;
-protect type debug-serialisation with internal;
+type debug-serialisation;
 
 // -- Perspectives
 
@@ -29,7 +27,8 @@ abstract perspective;
 /// The default perspective. Whenever one isn't specified, this will
 /// be used to represent the value. Generally the "most commonly useful"
 /// view of it.
-singleton default-perspective;
+type default-perspective is perspective;
+define default-perspective = new default-perspective;
 
 /// The minimal amount of commands that a perspective needs to provide
 /// for all of Crochet's debugging tools to work properly.
@@ -82,7 +81,7 @@ type doc-text(value is unsafe-arbitrary-text) is document;
 type doc-boolean(value is boolean) is document;
 
 /// A piece of text with no semantics.
-type doc-plain-text(name is text) is document;
+type doc-plain-text(value is text) is document;
 
 /// A list of values.
 type doc-list(items is list<document>) is document;

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -30,6 +30,9 @@ abstract perspective;
 type default-perspective is perspective;
 define default-perspective = new default-perspective;
 
+/// Shows the "source code" representation of a value.
+type source-perspective is perspective;
+
 /// The minimal amount of commands that a perspective needs to provide
 /// for all of Crochet's debugging tools to work properly.
 ///

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -149,8 +149,10 @@ type doc-typed(content is document, crochet-type is static-type) is document;
 type doc-group(compact is document, expanded is document) is document;
 
 /// A circle shape
-type doc-circle(x is doc-unit, y is doc-unit, radius is doc-unit, presentation is doc-presentation) is document;
+type doc-circle(center is doc-point2d, radius is doc-unit, presentation is doc-presentation) is document;
 
 /// A rectangle shape
 type doc-rectangle(origin is doc-point2d, size is doc-dimension, roundness is doc-point2d, presentation is doc-presentation) is document;
 
+/// An ellipse shape
+type doc-ellipse(center is doc-point2d, radius is doc-point2d, presentation is doc-presentation) is document;

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -109,3 +109,7 @@ type doc-position(content is document, position is doc-point2d, anchor is doc-po
 
 /// Marks a document as belonging to a specific type
 type doc-typed(content is document, crochet-type is static-type) is document;
+
+/// Allows the renderer to choose between a compact and expanded representation
+/// depending on its rendering context, amount of space available, etc.
+type doc-group(compact is document, expanded is document) is document;

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -83,6 +83,9 @@ type doc-boolean(value is boolean) is document;
 /// A piece of text with no semantics.
 type doc-plain-text(value is text) is document;
 
+/// A piece of text that's guaranteed to be rendered in monospaced font.
+type doc-code(value is text) is document;
+
 /// A list of values.
 type doc-list(items is list<document>) is document;
 

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -1,0 +1,112 @@
+% crochet
+
+// -- Module
+
+/// Allows defining (rich) ways of representing Crochet values
+/// according to a particular perspective.
+///
+/// You can define a debug representation for any type by providing
+/// a new [command:_ for: _ perspective: _] branch. A perspective
+/// has to be a nullary type extending [type:perspective] and
+/// implementing the [trait:debug-perspective] trait.
+singleton debug-representation;
+
+/// Used for serialisation. No powers are granted for external modules.
+singleton debug-serialisation;
+protect global debug-serialisation with internal;
+protect type debug-serialisation with internal;
+
+// -- Perspectives
+
+/// The base of all perspectives.
+///
+/// A perspective is a nullary type that allows selecting one of
+/// the debug representations, and extending these representations,
+/// without any coordination. This means that packages need not be
+/// aware of other packages' perspectives and representations.
+abstract perspective;
+
+/// The default perspective. Whenever one isn't specified, this will
+/// be used to represent the value. Generally the "most commonly useful"
+/// view of it.
+singleton default-perspective;
+
+/// The minimal amount of commands that a perspective needs to provide
+/// for all of Crochet's debugging tools to work properly.
+///
+/// Currently the only requirement is a [command:_ name] command, but
+/// more commands may be added in the future.
+trait debug-perspective with
+  /// Returns a human-readable description of the perspective. Used in
+  /// debugging tools to show the available ways they can inspect the
+  /// data.
+  command Perspective name -> text;
+end
+
+
+// -- Numeric values
+/// The base type of all numeric units used by documents.
+abstract doc-unit;
+
+/// No unit value
+singleton doc-unit-unset;
+
+/// Value in pixels.
+type doc-pixels(value is integer);
+
+/// Value in percentage (context-dependent).
+type doc-percent(value is float);
+
+/// Value in em units.
+type doc-em(value is float);
+
+/// A 2d point of doc units.
+type doc-point2d(x is doc-unit, y is doc-unit);
+
+
+// -- Document language
+
+/// The root of the document language.
+abstract document;
+
+/// The empty document
+singleton doc-empty is document;
+
+/// A numeric value.
+type doc-number(value is numeric) is document;
+
+/// A piece of Crochet text.
+type doc-text(value is unsafe-arbitrary-text) is document;
+
+/// A boolean.
+type doc-boolean(value is boolean) is document;
+
+/// A piece of text with no semantics.
+type doc-plain-text(name is text) is document;
+
+/// A list of values.
+type doc-list(items is list<document>) is document;
+
+/// A table of values.
+type doc-table(header is list<document>, rows is list<doc-table-row>) is document;
+
+/// A row in a table.
+type doc-table-row(cells is list<document>) is document;
+
+/// Lays its items with flow layouting.
+type doc-flow(items is list<document>) is document;
+
+/// Lays its items with a flex row.
+type doc-flex-row(items is list<document>, gap is doc-unit) is document;
+
+/// Lays its items with a flex column.
+type doc-flex-column(items is list<document>, gap is doc-unit) is document;
+
+/// Lays its items with fixed layout (the items need to be positioned)
+type doc-fixed-layout(items is list<document>, width is doc-unit, height is doc-unit) is document;
+
+/// Positions the item inside of a fixed layout container
+type doc-position(content is document, position is doc-point2d, anchor is doc-point2d) is document;
+
+/// Marks a document as belonging to a specific type
+type doc-typed(content is document, crochet-type is static-type) is document;

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -159,3 +159,9 @@ type doc-ellipse(center is doc-point2d, radius is doc-point2d, presentation is d
 
 /// A line shape
 type doc-line(from is doc-point2d, to is doc-point2d, presentation is doc-presentation) is document;
+
+/// A polygon shape
+type doc-polygon(points is list<doc-point2d>, presentation is doc-presentation) is document;
+
+/// A poly-line shape
+type doc-polyline(points is list<doc-point2d>, presentation is doc-presentation) is document;

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -51,20 +51,41 @@ end
 abstract doc-unit;
 
 /// No unit value
-singleton doc-unit-unset;
+singleton doc-unit-unset is doc-unit;
 
 /// Value in pixels.
-type doc-pixels(value is integer);
+type doc-pixels(value is integer) is doc-unit;
 
 /// Value in percentage (context-dependent).
-type doc-percent(value is float);
+type doc-percent(value is float) is doc-unit;
 
 /// Value in em units.
-type doc-em(value is float);
+type doc-em(value is float) is doc-unit;
 
 /// A 2d point of doc units.
 type doc-point2d(x is doc-unit, y is doc-unit);
 
+
+/// The base type of all colours used by documents.
+abstract doc-colour;
+
+/// No colour value
+singleton doc-colour-transparent is doc-colour;
+
+/// RGBA colour
+type doc-colour-rgba(
+  red is integer,
+  green is integer,
+  blue is integer,
+  alpha is integer,
+) is doc-colour;
+
+/// A way of formatting and presenting shapes
+type doc-presentation(
+  stroke-colour is doc-colour,
+  stroke-width is doc-unit,
+  fill-colour is doc-colour,
+);
 
 // -- Document language
 
@@ -119,3 +140,6 @@ type doc-typed(content is document, crochet-type is static-type) is document;
 /// Allows the renderer to choose between a compact and expanded representation
 /// depending on its rendering context, amount of space available, etc.
 type doc-group(compact is document, expanded is document) is document;
+
+/// A circle shape
+type doc-circle(x is doc-unit, y is doc-unit, radius is doc-unit, presentation is doc-presentation) is document;

--- a/tools/launcher/app/crochet.json
+++ b/tools/launcher/app/crochet.json
@@ -28,7 +28,12 @@
     "source/ipc.crochet",
     "source/main.crochet"
   ],
-  "native_sources": ["native/dom.js", "native/api.js", "native/ipc.js"],
+  "native_sources": [
+    "native/dom.js",
+    "native/api.js",
+    "native/ipc.js",
+    "native/lens.js"
+  ],
   "dependencies": [
     "crochet.core",
     "crochet.language.json",

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -16,7 +16,7 @@ export default (ffi: ForeignInterface) => {
     return element;
   }
 
-  function render(data: any): HTMLElement {
+  function render(data: any, compact = false): HTMLElement {
     if (data == null) {
       return h("div", { class: "value-lens-nothing" }, []);
     } else {
@@ -46,7 +46,7 @@ export default (ffi: ForeignInterface) => {
           return h(
             "div",
             { class: "value-lens-list" },
-            data.items.map((x: any) => render(x))
+            data.items.map((x: any) => render(x, true))
           );
 
         case "table":
@@ -54,14 +54,16 @@ export default (ffi: ForeignInterface) => {
             h(
               "div",
               { class: "value-lens-table-header" },
-              data.header.map((x: any) => render(x))
+              data.header.map((x: any) => render(x, true))
             ),
             ...data.rows.map((x: any) =>
               h(
                 "div",
                 { class: "value-lens-table-row" },
                 x.map((y: any) =>
-                  h("div", { class: "value-lens-table-cell" }, [render(y)])
+                  h("div", { class: "value-lens-table-cell" }, [
+                    render(y, true),
+                  ])
                 )
               )
             ),
@@ -71,33 +73,33 @@ export default (ffi: ForeignInterface) => {
           return h(
             "div",
             { class: "value-lens-flow" },
-            data.items.map((x: any) => render(x))
+            data.items.map((x: any) => render(x, compact))
           );
 
         case "flex-row":
           return h(
             "div",
             { class: "value-lens-flex-row" },
-            data.items.map((x: any) => render(x))
+            data.items.map((x: any) => render(x, compact))
           );
 
         case "flex-column":
           return h(
             "div",
             { class: "value-lens-flex-column" },
-            data.items.map((x: any) => render(x))
+            data.items.map((x: any) => render(x, compact))
           );
 
         case "fixed-layout":
           return h(
             "div",
             { class: "value-lens-fixed-layout" },
-            data.items.map((x: any) => render(x))
+            data.items.map((x: any) => render(x, compact))
           );
 
         case "position":
           return h("div", { class: "value-lens-position" }, [
-            render(data.content),
+            render(data.content, compact),
           ]);
 
         case "typed":
@@ -111,9 +113,40 @@ export default (ffi: ForeignInterface) => {
               ]),
             ]),
             h("div", { class: "value-lens-typed-value" }, [
-              render(data.content),
+              render(data.content, compact),
             ]),
           ]);
+
+        case "group": {
+          let state = compact;
+          const button = h("div", { class: "value-lens-group-button" }, [
+            h("i", { class: "fas fa-plus" }, []),
+          ]);
+          const element = h(
+            "div",
+            { class: "value-lens-group", "data-compact": String(state) },
+            [
+              button,
+              h("div", { class: "value-lens-group-contents" }, [
+                h("div", { class: "value-lens-group-compact" }, [
+                  render(data.compact),
+                ]),
+                h("div", { class: "value-lens-group-expanded" }, [
+                  render(data.expanded),
+                ]),
+              ]),
+            ]
+          );
+          button.addEventListener("click", (ev) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            state = !state;
+            const icon = state ? "fa-plus" : "fa-minus";
+            element.setAttribute("data-compact", String(state));
+            button.querySelector("i")!.className = `fas ${icon}`;
+          });
+          return element;
+        }
 
         default:
           return h("div", { class: "value-lens-unknown" }, [

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -303,12 +303,33 @@ export default (ffi: ForeignInterface) => {
 
         case "circle": {
           const svg = make_svg();
+          const center = compile_point2d(data.center);
           const circle = h(
             "circle",
             {
-              cx: compile_unit(data.x) ?? "0",
-              cy: compile_unit(data.y) ?? "0",
-              r: compile_unit(data.radius) ?? "0",
+              cx: center.x ?? "0px",
+              cy: center.y ?? "0px",
+              r: compile_unit(data.radius) ?? "0px",
+              ...svg_presentation(compile_presentation(data.presentation)),
+            },
+            [],
+            svgNS
+          );
+          svg.append(circle);
+          return fix_svg_box(svg);
+        }
+
+        case "ellipse": {
+          const svg = make_svg();
+          const center = compile_point2d(data.center);
+          const radius = compile_point2d(data.radius);
+          const circle = h(
+            "ellipse",
+            {
+              cx: center.x ?? "0px",
+              cy: center.y ?? "0px",
+              rx: radius.x ?? "0px",
+              ry: radius.y ?? "0px",
               ...svg_presentation(compile_presentation(data.presentation)),
             },
             [],

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -382,12 +382,12 @@ export default (ffi: ForeignInterface) => {
           const svg = make_svg();
           const points = (data.points as any[])
             .map(compile_point2d)
-            .map((p) => (p == null ? null : `${p.x}, ${p.y}`))
+            .map((p) => (p == null ? null : `${p.x},${p.y}`))
             .filter((x) => x != null);
           const polygon = h(
             "polygon",
             {
-              points: points.join(", "),
+              points: points.join(" "),
               ...svg_presentation(compile_presentation(data.presentation)),
             },
             [],
@@ -401,12 +401,12 @@ export default (ffi: ForeignInterface) => {
           const svg = make_svg();
           const points = (data.points as any[])
             .map(compile_point2d)
-            .map((p) => (p == null ? null : `${p.x}, ${p.y}`))
+            .map((p) => (p == null ? null : `${p.x},${p.y}`))
             .filter((x) => x != null);
           const polygon = h(
             "polyline",
             {
-              points: points.join(", "),
+              points: points.join(" "),
               ...svg_presentation(compile_presentation(data.presentation)),
             },
             [],

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -42,6 +42,9 @@ export default (ffi: ForeignInterface) => {
         case "plain-text":
           return h("div", { class: "value-lens-plain-text" }, [data.value]);
 
+        case "code":
+          return h("div", { class: "value-lens-code" }, [data.value]);
+
         case "list":
           return h(
             "div",

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -61,9 +61,9 @@ export default (ffi: ForeignInterface) => {
     );
     document.body.append(measure);
     measure.append(svg);
-    const bounds = svg.getBBox();
-    svg.setAttribute("width", `${bounds.width}px`);
-    svg.setAttribute("height", `${bounds.height}px`);
+    const bounds = svg.getBBox({ stroke: true, fill: true });
+    svg.setAttribute("width", `${bounds.x + bounds.width}px`);
+    svg.setAttribute("height", `${bounds.y + bounds.height}px`);
     measure.remove();
     return svg;
   }

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -49,7 +49,9 @@ export default (ffi: ForeignInterface) => {
           return h(
             "div",
             { class: "value-lens-list" },
-            data.items.map((x: any) => render(x, true))
+            data.items.map((x: any) =>
+              h("div", { class: "value-lens-list-item" }, [render(x, true)])
+            )
           );
 
         case "table":
@@ -57,7 +59,9 @@ export default (ffi: ForeignInterface) => {
             h(
               "div",
               { class: "value-lens-table-header" },
-              data.header.map((x: any) => render(x, true))
+              data.header.map((x: any) =>
+                h("div", { class: "value-lens-table-cell" }, [render(x, true)])
+              )
             ),
             ...data.rows.map((x: any) =>
               h(
@@ -76,7 +80,9 @@ export default (ffi: ForeignInterface) => {
           return h(
             "div",
             { class: "value-lens-flow" },
-            data.items.map((x: any) => render(x, compact))
+            data.items.map((x: any) =>
+              h("div", { class: "value-lens-flow-item" }, [render(x, compact)])
+            )
           );
 
         case "flex-row":
@@ -111,6 +117,7 @@ export default (ffi: ForeignInterface) => {
               h("div", { class: "value-lens-typed-type-name" }, [
                 data["type-name"],
               ]),
+              " in ",
               h("div", { class: "value-lens-typed-type-package" }, [
                 data["package-name"],
               ]),
@@ -153,7 +160,7 @@ export default (ffi: ForeignInterface) => {
 
         default:
           return h("div", { class: "value-lens-unknown" }, [
-            JSON.stringify(data),
+            JSON.stringify(data, null, 2),
           ]);
       }
     }
@@ -161,6 +168,6 @@ export default (ffi: ForeignInterface) => {
 
   ffi.defun("lens.render", (json) => {
     const data = JSON.parse(ffi.text_to_string(json));
-    return ffi.box(render(data));
+    return ffi.box(h("div", { class: "value-lens-container" }, [render(data)]));
   });
 };

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -68,13 +68,13 @@ export default (ffi: ForeignInterface) => {
     return svg;
   }
 
-  function compile_point2d(data: any) {
+  function compile_point2d(data: any, unit = compile_unit) {
     if (data.tag !== "point-2d") {
       throw ffi.panic("invalid-type", `Expected point2d`);
     }
     return {
-      x: compile_unit(data.x),
-      y: compile_unit(data.y),
+      x: unit(data.x),
+      y: unit(data.y),
     };
   }
 
@@ -118,6 +118,22 @@ export default (ffi: ForeignInterface) => {
           })`;
         default:
           throw ffi.panic("invalid-type", `Unknown colour tag ${data.tag}`);
+      }
+    }
+  }
+
+  function compile_pixel_unit(data: any) {
+    if (data == null) {
+      return "0";
+    } else {
+      switch (data.unit) {
+        case "pixel":
+          return String(data.value);
+        default:
+          throw ffi.panic(
+            "invalid-unit",
+            `Only pixels are allowed, got ${data.unit}`
+          );
       }
     }
   }
@@ -381,7 +397,7 @@ export default (ffi: ForeignInterface) => {
         case "polygon": {
           const svg = make_svg();
           const points = (data.points as any[])
-            .map(compile_point2d)
+            .map((x) => compile_point2d(x, compile_pixel_unit))
             .map((p) => (p == null ? null : `${p.x},${p.y}`))
             .filter((x) => x != null);
           const polygon = h(
@@ -400,7 +416,7 @@ export default (ffi: ForeignInterface) => {
         case "polyline": {
           const svg = make_svg();
           const points = (data.points as any[])
-            .map(compile_point2d)
+            .map((x) => compile_point2d(x, compile_pixel_unit))
             .map((p) => (p == null ? null : `${p.x},${p.y}`))
             .filter((x) => x != null);
           const polygon = h(

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -1,0 +1,130 @@
+import type { ForeignInterface, CrochetValue } from "../../../../build/crochet";
+
+export default (ffi: ForeignInterface) => {
+  function h(
+    tag: string,
+    attrs: { [key: string]: string },
+    children: (Node | string)[]
+  ) {
+    const element = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      element.setAttribute(k, v);
+    }
+    for (const x of children) {
+      element.append(x);
+    }
+    return element;
+  }
+
+  function render(data: any): HTMLElement {
+    if (data == null) {
+      return h("div", { class: "value-lens-nothing" }, []);
+    } else {
+      switch (data.tag) {
+        case "empty":
+          return h("div", { class: "value-lens-empty" }, []);
+
+        case "number":
+          return h("div", { class: "value-lens-number" }, [data.value]);
+
+        case "text":
+          return h(
+            "div",
+            { class: "value-lens-text", "data-untrusted": data.untrusted },
+            [data.value]
+          );
+
+        case "boolean":
+          return h("div", { class: "value-lens-boolean" }, [
+            String(data.value),
+          ]);
+
+        case "plain-text":
+          return h("div", { class: "value-lens-plain-text" }, [data.value]);
+
+        case "list":
+          return h(
+            "div",
+            { class: "value-lens-list" },
+            data.items.map((x: any) => render(x))
+          );
+
+        case "table":
+          return h("div", { class: "value-lens-table" }, [
+            h(
+              "div",
+              { class: "value-lens-table-header" },
+              data.header.map((x: any) => render(x))
+            ),
+            ...data.rows.map((x: any) =>
+              h(
+                "div",
+                { class: "value-lens-table-row" },
+                x.map((y: any) =>
+                  h("div", { class: "value-lens-table-cell" }, [render(y)])
+                )
+              )
+            ),
+          ]);
+
+        case "flow":
+          return h(
+            "div",
+            { class: "value-lens-flow" },
+            data.items.map((x: any) => render(x))
+          );
+
+        case "flex-row":
+          return h(
+            "div",
+            { class: "value-lens-flex-row" },
+            data.items.map((x: any) => render(x))
+          );
+
+        case "flex-column":
+          return h(
+            "div",
+            { class: "value-lens-flex-column" },
+            data.items.map((x: any) => render(x))
+          );
+
+        case "fixed-layout":
+          return h(
+            "div",
+            { class: "value-lens-fixed-layout" },
+            data.items.map((x: any) => render(x))
+          );
+
+        case "position":
+          return h("div", { class: "value-lens-position" }, [
+            render(data.content),
+          ]);
+
+        case "typed":
+          return h("div", { class: "value-lens-typed" }, [
+            h("div", { class: "value-lens-typed-type" }, [
+              h("div", { class: "value-lens-typed-type-name" }, [
+                data["type-name"],
+              ]),
+              h("div", { class: "value-lens-typed-type-package" }, [
+                data["package-name"],
+              ]),
+            ]),
+            h("div", { class: "value-lens-typed-value" }, [
+              render(data.content),
+            ]),
+          ]);
+
+        default:
+          return h("div", { class: "value-lens-unknown" }, [
+            JSON.stringify(data),
+          ]);
+      }
+    }
+  }
+
+  ffi.defun("lens.render", (json) => {
+    const data = JSON.parse(ffi.text_to_string(json));
+    return ffi.box(render(data));
+  });
+};

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -358,6 +358,26 @@ export default (ffi: ForeignInterface) => {
           return fix_svg_box(svg);
         }
 
+        case "line": {
+          const svg = make_svg();
+          const from = compile_point2d(data.from);
+          const to = compile_point2d(data.to);
+          const line = h(
+            "line",
+            {
+              x1: from.x ?? "0px",
+              y1: from.y ?? "0px",
+              x2: to.x ?? "0px",
+              y2: to.y ?? "0px",
+              ...svg_presentation(compile_presentation(data.presentation)),
+            },
+            [],
+            svgNS
+          );
+          svg.append(line);
+          return fix_svg_box(svg);
+        }
+
         default:
           return h("div", { class: "value-lens-unknown" }, [
             JSON.stringify(data, null, 2),

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -44,6 +44,30 @@ export default (ffi: ForeignInterface) => {
     return element;
   }
 
+  function fix_svg_box(svg: SVGSVGElement) {
+    const measure = h(
+      "div",
+      {
+        style: {
+          position: "absolute",
+          top: "-1000px",
+          height: "-1000px",
+          width: "1px",
+          overflow: "hidden",
+          visibility: "hidden",
+        },
+      },
+      []
+    );
+    document.body.append(measure);
+    measure.append(svg);
+    const bounds = svg.getBBox();
+    svg.setAttribute("width", `${bounds.width}px`);
+    svg.setAttribute("height", `${bounds.height}px`);
+    measure.remove();
+    return svg;
+  }
+
   function compile_point2d(data: any) {
     if (data.tag !== "point-2d") {
       throw ffi.panic("invalid-type", `Expected point2d`);
@@ -89,7 +113,9 @@ export default (ffi: ForeignInterface) => {
     } else {
       switch (data.tag) {
         case "rgba":
-          return `rgba(${data.red}, ${data.green}, ${data.blue}, ${data.alpha})`;
+          return `rgba(${data.red}, ${data.green}, ${data.blue}, ${
+            data.alpha / 255
+          })`;
         default:
           throw ffi.panic("invalid-type", `Unknown colour tag ${data.tag}`);
       }
@@ -97,7 +123,7 @@ export default (ffi: ForeignInterface) => {
   }
 
   function compile_unit(data: any) {
-    if (data.unit == null) {
+    if (data == null) {
       return null;
     }
 
@@ -289,7 +315,7 @@ export default (ffi: ForeignInterface) => {
             svgNS
           );
           svg.append(circle);
-          return svg;
+          return fix_svg_box(svg);
         }
 
         case "rectangle": {
@@ -308,7 +334,7 @@ export default (ffi: ForeignInterface) => {
             svgNS
           );
           svg.append(rect);
-          return svg;
+          return fix_svg_box(svg);
         }
 
         default:

--- a/tools/launcher/app/native/lens.ts
+++ b/tools/launcher/app/native/lens.ts
@@ -378,6 +378,44 @@ export default (ffi: ForeignInterface) => {
           return fix_svg_box(svg);
         }
 
+        case "polygon": {
+          const svg = make_svg();
+          const points = (data.points as any[])
+            .map(compile_point2d)
+            .map((p) => (p == null ? null : `${p.x}, ${p.y}`))
+            .filter((x) => x != null);
+          const polygon = h(
+            "polygon",
+            {
+              points: points.join(", "),
+              ...svg_presentation(compile_presentation(data.presentation)),
+            },
+            [],
+            svgNS
+          );
+          svg.append(polygon);
+          return fix_svg_box(svg);
+        }
+
+        case "polyline": {
+          const svg = make_svg();
+          const points = (data.points as any[])
+            .map(compile_point2d)
+            .map((p) => (p == null ? null : `${p.x}, ${p.y}`))
+            .filter((x) => x != null);
+          const polygon = h(
+            "polyline",
+            {
+              points: points.join(", "),
+              ...svg_presentation(compile_presentation(data.presentation)),
+            },
+            [],
+            svgNS
+          );
+          svg.append(polygon);
+          return fix_svg_box(svg);
+        }
+
         default:
           return h("div", { class: "value-lens-unknown" }, [
             JSON.stringify(data, null, 2),

--- a/tools/launcher/app/source/0-types.crochet
+++ b/tools/launcher/app/source/0-types.crochet
@@ -12,8 +12,11 @@ type event-stream(
 type subscriber(handler is (A -> nothing));
 
 abstract value-lens;
+type vl-perspectives(perspectives is list<vl-representation>) is value-lens;
 type vl-raw(global code is text) is value-lens;
 singleton vl-nothing is value-lens;
+
+type vlp-representation(name, document);
 
 // Managing projects
 type purr-project-meta(

--- a/tools/launcher/app/source/lens.crochet
+++ b/tools/launcher/app/source/lens.crochet
@@ -6,6 +6,11 @@ command #value-lens parse-plain: (Lens is record) do
   condition
     when Lens.tag === "RAW" =>
       new vl-raw(Lens.code);
+    
+    when Lens.tag === "PERSPECTIVES" =>
+      new vl-perspectives(Lens.perspectives map: { R in
+        new vlp-representation(R.name, R.document)
+      });
   end
 end
 
@@ -20,6 +25,19 @@ command vl-raw as widget do
   ];
 end
 
+command vl-perspectives as widget do
+  w tabbed-panel: (
+    self.perspectives map: (_ as widget)
+  );
+end
+
 command vl-nothing as widget do
   w fragment: [];
+end
+
+implement to-widget for vlp-representation;
+command vlp-representation as widget do
+  w
+    | tab: self.name
+    | with: [new w-committed(new dom-node(foreign lens.render(self.document)))]
 end

--- a/tools/launcher/package-lock.json
+++ b/tools/launcher/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@origamitower/crochet-launcher",
+  "name": "@qteatime/crochet-launcher",
   "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@origamitower/crochet-launcher",
+      "name": "@qteatime/crochet-launcher",
       "version": "0.12.0",
       "dependencies": {
         "express": "^4.17.1",

--- a/tools/launcher/source/client/repl.ts
+++ b/tools/launcher/source/client/repl.ts
@@ -57,10 +57,19 @@ export class ReplStatements extends ReplExpr {
       }
     }
 
+    const perspectives = await process.vm.system.debug_perspectives(value);
+    const representations = await process.vm.system.debug_representations(
+      value,
+      perspectives
+    );
+
     client.post_message("playground/success", {
       value: {
-        tag: "RAW",
-        code: VM.Location.simple_value(value),
+        tag: "PERSPECTIVES",
+        perspectives: representations.map((x) => ({
+          name: x.name,
+          document: JSON.stringify(x.document),
+        })),
       },
     });
   }

--- a/tools/launcher/www/media/agata.css
+++ b/tools/launcher/www/media/agata.css
@@ -570,7 +570,7 @@ body {
 
 .value-lens-unknown {
   font-family: "Source Sans Pro", monospace;
-  white-space: pre;
+  white-space: pre-wrap;
   padding: 0.5em;
   border: 1px dashed #9b9b9b;
 }
@@ -615,7 +615,7 @@ body {
 
 .value-lens-code {
   font-family: "Source Sans Pro", monospace;
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 .value-lens-list {

--- a/tools/launcher/www/media/agata.css
+++ b/tools/launcher/www/media/agata.css
@@ -562,3 +562,168 @@ body {
   text-transform: uppercase;
   font-size: 0.9em;
 }
+
+/* -- Value lenses */
+.value-lens-container {
+  margin: 1em 0;
+}
+
+.value-lens-unknown {
+  font-family: "Source Sans Pro", monospace;
+  white-space: pre;
+  padding: 0.5em;
+  border: 1px dashed #9b9b9b;
+}
+
+.value-lens-nothing {
+  display: none;
+}
+
+.value-lens-empty {
+  display: none;
+}
+
+.value-lens-number {
+  color: #039be5;
+}
+
+.value-lens-text {
+  color: #00796b;
+}
+.value-lens-text::before {
+  content: "“";
+  color: #525252;
+}
+.value-lens-text::after {
+  content: "”";
+  color: #525252;
+}
+
+.value-lens-text[data-untrusted="true"] {
+  color: #d32f2f;
+}
+
+.value-lens-text[data-untrusted="true"]::before {
+  content: "(untrusted text) “";
+  color: #525252;
+  margin-right: 0.5em;
+}
+
+.value-lens-boolean {
+  font-weight: bold;
+}
+
+.value-lens-code {
+  font-family: "Source Sans Pro", monospace;
+  white-space: pre;
+}
+
+.value-lens-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #ececea;
+}
+
+.value-lens-list-item {
+  border-bottom: 1px solid #ececea;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.value-lens-list-item:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+
+.value-lens-table {
+  border: 1px solid #ececea;
+  display: table;
+  border-collapse: collapse;
+}
+
+.value-lens-table-header,
+.value-lens-table-row {
+  display: table-row;
+}
+
+.value-lens-table-cell {
+  display: table-cell;
+  padding: 0.5em;
+  border: 1px solid #ececea;
+}
+
+.value-lens-table-header > .value-lens-table-cell {
+  background: #ececea;
+  text-align: center;
+  font-weight: bold;
+}
+
+.value-lens-flow,
+.value-lens-flow-item {
+  display: inline-block;
+}
+
+.value-lens-flex-row {
+  display: flex;
+  flex-direction: row;
+}
+
+.value-lens-flex-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.value-lens-fixed-layout {
+  position: relative;
+  overflow: hidden;
+}
+
+.value-lens-position {
+  position: absolute;
+}
+
+.value-lens-typed {
+  display: flex;
+  flex-direction: column;
+}
+
+.value-lens-typed-type {
+  display: flex;
+  flex-direction: row;
+  gap: 0.3em;
+  text-transform: uppercase;
+  font-size: 0.8em;
+  color: #7a7a7a;
+  line-height: 1.6em;
+}
+
+.value-lens-typed-value {
+  padding: 0.5em;
+}
+
+.value-lens-group {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 0.3em;
+}
+
+.value-lens-group-button {
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+  font-size: 9px;
+  text-align: center;
+  background: #039be5;
+  border-radius: 100%;
+  color: #fafafa;
+}
+
+.value-lens-group[data-compact="true"]
+  > .value-lens-group-contents
+  > .value-lens-group-expanded,
+.value-lens-group[data-compact="false"]
+  > .value-lens-group-contents
+  > .value-lens-group-compact {
+  display: none;
+}


### PR DESCRIPTION
This patch introduces a new debugging tool called "debug representations", where types can define multiple (rich and interactive) perspectives of how they'd like to be viewed in the playground, transcript, console, etc.

Representations and perspectives are capability-secure, and extensible without coordination (it's possible to add new perspectives and representations to an object without any other package being required to change its code or be aware of it).

This initial implementation uses a very restricted language for the representations because richer representations require far more security considerations (e.g.: think about the potential of phishing/confusing attacks if a package can simulate representations that *look* like native representations). So there will be follow ups to extend this language with the required security and privacy consideration that it requires.

This patch assumes code is primarily written and debugged from the interactive playground. Because the document language allows serialisation, this works even if objects live in different processes or programming languages, which is important for the Purr project.