### PR TITLE
Allow capabilities to be referenced before they're defined

### DIFF
--- a/source/crochet/crochet.ts
+++ b/source/crochet/crochet.ts
@@ -228,6 +228,7 @@ export class BootedCrochet {
 
     VM.Types.verify_package_types(cpkg);
     VM.Types.verify_package_traits(cpkg);
+    VM.Capability.verify_package_capabilities(cpkg);
   }
 
   private reify_capability_grants(pkg: Package.ResolvedPackage) {

--- a/source/vm/boot.ts
+++ b/source/vm/boot.ts
@@ -721,12 +721,26 @@ export function load_declaration(
     }
 
     case t.CAPABILITY: {
-      const capability = new CrochetCapability(
+      const new_capability = new CrochetCapability(
         module,
         declaration.name,
         declaration.documentation,
         declaration.meta
       );
+      let capability;
+      const missing = Capability.try_get_placeholder_capability(
+        module,
+        declaration.name
+      );
+      if (missing != null) {
+        capability = Capability.fulfill_placeholder_capability(
+          module,
+          missing,
+          new_capability
+        );
+      } else {
+        capability = new_capability;
+      }
       Capability.define_capability(module, capability);
       break;
     }

--- a/source/vm/intrinsics.ts
+++ b/source/vm/intrinsics.ts
@@ -364,6 +364,7 @@ export class CrochetWorld {
 export class CrochetPackage {
   readonly missing_traits: Namespace<CrochetTrait>;
   readonly missing_types: Namespace<CrochetType>;
+  readonly missing_capabilities: Namespace<CrochetCapability>;
   readonly types: PassthroughNamespace<CrochetType>;
   readonly traits: PassthroughNamespace<CrochetTrait>;
   readonly definitions: PassthroughNamespace<CrochetValue>;
@@ -382,6 +383,7 @@ export class CrochetPackage {
   ) {
     this.missing_traits = new Namespace(null, null, null);
     this.missing_types = new Namespace(null, null, null);
+    this.missing_capabilities = new Namespace(null, null, null);
     this.types = new PassthroughNamespace(world.types, name);
     this.traits = new PassthroughNamespace(world.traits, name);
     this.definitions = new PassthroughNamespace(world.definitions, name);

--- a/tests/vm-tests/capabilities.crochet
+++ b/tests/vm-tests/capabilities.crochet
@@ -1,0 +1,7 @@
+% crochet
+
+// We can refer to capabilities before they're defined
+type capability-protected;
+protect type capability-protected with protecc;
+
+capability protecc;

--- a/tests/vm-tests/crochet.json
+++ b/tests/vm-tests/crochet.json
@@ -30,7 +30,8 @@
     "actions.crochet",
     "effects.crochet",
     "dsl.crochet",
-    "traits.crochet"
+    "traits.crochet",
+    "capabilities.crochet"
   ],
   "capabilities": {
     "requires": ["crochet.debug/internal"],


### PR DESCRIPTION
This was missed when adding type and trait placeholders in #47. This extends the possibility of referring to capabilities before they're defined.