### PR TITLE
Add concurrency primitives

### DIFF
--- a/docs/design/0010-concurrency.md
+++ b/docs/design/0010-concurrency.md
@@ -1,0 +1,116 @@
+# [#0009] - Concurrency primitives
+
+|                  |                   |
+| ---------------- | ----------------- |
+| **Authors**      | Q.                |
+| **Last updated** | 13th January 2022 |
+| **Status**       | Draft             |
+
+## Summary
+
+Crochet's concurrency is mostly based on cooperative processes, with
+preemptive concurrency being entirely isolated with Zones (similar to
+E's vats, which can also be distributed easily).
+
+This document describes some of the cooperative concurrency primitives.
+In particular, Crochet takes the following approach to concurrency:
+
+- State machines are modelled as `actors` (which belong to Zones and
+  can migrate between them);
+
+- Tasks are modelled with `task`, `deferred`, and `promise`. This includes
+  capabilities to cancel and asynchronous resource handling.
+
+- Producing values and communicating within a zone is modelled with
+  CSP `channel`s, which allows backpressure handling.
+
+- Broadcasting values is modelled with reactive `event-stream`s and
+  `observable`s. This does not support backpressure, but supports
+  multiple listeners. And they're the core features of reactive
+  capabilities in Crochet.
+
+## Actors
+
+Actors in Crochet are state machines. They're modelled as a type
+that holds a mailbox **and** a current state. The current state
+is a type that implements `actor-state`, a trait that allows the
+state to define which messages it accepts and handles.
+
+This gives you the following:
+
+    singleton idle-phone is actor-state;
+    type connected-phone(connected-to) is actor-state;
+
+
+    command idle-phone accepts: connect = true;
+    command idle-phone handle: (M is connect) =
+      self transition-to: new connected-phone(M.target);
+
+
+    command connected-phone accepts: receive = true;
+    command connected-phone handle: (M is receive) = ...;
+
+    command connected-phone accepts: send = true;
+    command connected-phone handle: (M is send) = ...;
+
+    command connected-phone accepts: hang-up = true;
+    command connected-phone handle: (M is hang-up) =
+      self transition-to: idle-phone;
+
+
+    define actor = #actor with-state: idle-phone;
+
+This is a state machine with two states: phones can be either idle
+or connected. When a phone is idle, the only thing it can do is
+accept incoming connections. When a phone is connected it can't
+accept incoming connections before hanging up. If this actor receives
+a message that the current state can't handle, it just sits in the
+mailbox until it transitions to a state that does accept it. The idea
+is similar to Erlang's `receive` block, just done with commands and
+types instead of functions and pattern matching.
+
+## Tasks, Deferreds, Promises
+
+These are modelled after the previous work on Folktale's concurrency
+primitives: https://folktale.origamitower.com/api/v2.3.0/en/folktale.concurrency.html
+
+However, as they do not have a formal model of concurrency specified
+yet (unlike actors that are more well understood), there needs to
+be some work in drafting a formal model for it. That work will be
+done in a future proposal.
+
+## Channels
+
+CSP channels are a well-understood formal model for concurrency.
+Crochet's implementation however takes inspiration from Clojure's
+core.async, which is **not** the same as Hoare's original formulation.
+
+In particular, Channels are given a bit more flexibility by allowing
+one to specify the backing buffering storage of the channel (and this
+in turn controls how and when synchronisation happens). And they are
+also given a more first-class and functional API.
+
+## Events and observables
+
+Event streams are roughly based on Rx's Observables idea. They're
+a push-based, unbuffered (by default) stream that has a functional
+API on top.
+
+Observables, on the other hand, are roughly based on synchronous
+variables from data-flow/synchronous languages, such as Lucid.
+In this case, each observable _is_ a stream (it's potentially
+many different values), but it also includes a cursor to some
+point of this stream.
+
+This means that you can have something like:
+
+    let Seen = search Player at: Where, Who at: Where, if Who =/= Player
+                 | observable;
+    ui show: "You see [Seen]";
+
+In this example, it looks like we're getting just one value
+at a particular point in time and outputting on the screen, but
+given how interpolations and observables work, this is actually
+an _active_ value---the text on the screen is automatically
+updated every time the facts in the database change, and the
+search can be ran entirely incrementally.

--- a/source/targets/browser/browser.ts
+++ b/source/targets/browser/browser.ts
@@ -36,6 +36,7 @@ export class CrochetForBrowser {
     // TODO: restrict TCB (needs safer native modules support)
     return new Set([
       "crochet.codec.basic",
+      "crochet.concurrency",
       "crochet.core",
       "crochet.debug",
       "crochet.debug.tracing",

--- a/source/targets/node/node.ts
+++ b/source/targets/node/node.ts
@@ -63,6 +63,7 @@ export class CrochetForNode {
     // TODO: restrict TCB (needs safer native modules support)
     return new Set([
       "crochet.codec.basic",
+      "crochet.concurrency",
       "crochet.core",
       "crochet.debug",
       "crochet.debug.tracing",

--- a/stdlib/crochet.concurrency/crochet.json
+++ b/stdlib/crochet.concurrency/crochet.json
@@ -1,0 +1,18 @@
+{
+  "name": "crochet.concurrency",
+  "target": "*",
+  "native_sources": ["native/promise.js", "native/timer.js", "native/actor.js"],
+  "sources": [
+    "source/internal.crochet",
+    "source/actor.crochet",
+    "source/event-stream.crochet",
+    "source/observable-cell.crochet",
+    "source/promise.crochet",
+    "source/timer.crochet"
+  ],
+  "dependencies": ["crochet.core", "crochet.time"],
+  "capabilities": {
+    "requires": [],
+    "provides": []
+  }
+}

--- a/stdlib/crochet.concurrency/native/actor.ts
+++ b/stdlib/crochet.concurrency/native/actor.ts
@@ -1,0 +1,12 @@
+import type { ForeignInterface, CrochetValue } from "../../../build/crochet";
+
+export default (ffi: ForeignInterface) => {
+  ffi.defun("actor.turn", (fn) => {
+    setImmediate(() => {
+      ffi.run_asynchronously(function* () {
+        return yield ffi.apply(fn, []);
+      });
+    });
+    return ffi.nothing;
+  });
+};

--- a/stdlib/crochet.concurrency/native/promise.ts
+++ b/stdlib/crochet.concurrency/native/promise.ts
@@ -1,0 +1,103 @@
+import type { ForeignInterface, CrochetValue } from "../../../build/crochet";
+
+export default (ffi: ForeignInterface) => {
+  class Deferred<A, B, S> {
+    private _resolve: (_: A) => void;
+    private _reject: (_: B) => void;
+    state: S;
+    promise: Promise<A>;
+    is_cancelled: boolean;
+    is_resolved: boolean;
+
+    constructor(state: S) {
+      this.state = state;
+      this.is_resolved = false;
+      this.is_cancelled = false;
+      this._resolve = null as any;
+      this._reject = null as any;
+      this.promise = new Promise((resolve, reject) => {
+        this._resolve = resolve;
+        this._reject = reject;
+      });
+    }
+
+    cancel(x: any) {
+      if (this.is_resolved || this.is_cancelled) return;
+      this.is_cancelled = true;
+      this._reject(x);
+    }
+
+    resolve(x: A) {
+      if (this.is_resolved || this.is_cancelled) return;
+      this.is_resolved = true;
+      this._resolve(x);
+    }
+
+    reject(x: B) {
+      if (this.is_resolved || this.is_cancelled) return;
+      this.is_resolved = true;
+      this._reject(x);
+    }
+  }
+
+  function get_deferred(x0: CrochetValue) {
+    const x = ffi.unbox(x0);
+    if (x instanceof Deferred) {
+      return x;
+    } else {
+      throw ffi.panic("invalid-type", "Expected a native deferred");
+    }
+  }
+
+  ffi.defun("promise.defer", (state) => {
+    return ffi.box(new Deferred(state));
+  });
+
+  ffi.defun("promise-is-resolved", (x) => {
+    return ffi.boolean(get_deferred(x).is_resolved);
+  });
+
+  ffi.defun("promise.is-cancelled", (x) => {
+    return ffi.boolean(get_deferred(x).is_cancelled);
+  });
+
+  ffi.defun("promise.state", (x) => {
+    return get_deferred(x).state;
+  });
+
+  ffi.defun("promise.cancel", (x, v) => {
+    get_deferred(x).cancel(v);
+    return ffi.nothing;
+  });
+
+  ffi.defun("promise.resolve", (x, v) => {
+    get_deferred(x).resolve(v);
+    return ffi.nothing;
+  });
+
+  ffi.defun("promise.reject", (x, v) => {
+    get_deferred(x).reject(v);
+    return ffi.nothing;
+  });
+
+  ffi.defun("promise.then", (x, f, g) => {
+    get_deferred(x).promise.then(
+      (value) => {
+        return ffi.run_asynchronously(function* () {
+          return yield ffi.apply(f, [value]);
+        });
+      },
+      (reason) => {
+        return ffi.run_asynchronously(function* () {
+          return yield ffi.apply(g, [reason]);
+        });
+      }
+    );
+    return ffi.nothing;
+  });
+
+  ffi.defmachine("promise.wait", function* (x) {
+    const result = yield ffi.await(get_deferred(x).promise);
+    return result;
+  });
+};

--- a/stdlib/crochet.concurrency/native/timer.ts
+++ b/stdlib/crochet.concurrency/native/timer.ts
@@ -1,0 +1,13 @@
+import type { ForeignInterface, CrochetValue } from "../../../build/crochet";
+
+export default (ffi: ForeignInterface) => {
+  ffi.defun("timer.wait", (ms0, fn) => {
+    const ms = Number(ffi.integer_to_bigint(ms0));
+    setTimeout(() => {
+      ffi.run_asynchronously(function* () {
+        return yield ffi.apply(fn, []);
+      });
+    }, ms);
+    return ffi.nothing;
+  });
+};

--- a/stdlib/crochet.concurrency/source/actor.crochet
+++ b/stdlib/crochet.concurrency/source/actor.crochet
@@ -1,0 +1,103 @@
+% crochet
+
+// TODO: This is a hack. We need to reify actors and zones in the runtime.
+type zone;
+
+type actor(zone is zone, process is actor-internal);
+
+type actor-internal(
+  mailbox is cell<list<actor-message>>,
+  state is cell<actor-state>,
+  busy is cell<boolean>,
+);
+
+abstract actor-message;
+abstract actor-state;
+
+abstract actor-message-result;
+singleton amr-done is actor-message-result;
+type amr-transition(new-state) is actor-message-result;
+
+
+// -- Zones 
+define root-zone = new zone;
+
+command zone spawn: (Initial-state is actor-state) =
+  new actor(self, new actor-internal(
+    mailbox -> #cell with-value: [],
+    state -> #cell with-value: Initial-state,
+    busy -> #cell with-value: false
+  ));
+
+
+// -- Actors
+command actor send: (Message is actor-message) do
+  self.process store-message: Message;
+  foreign actor.turn({ self.process wake-up } capture);
+  self;
+end
+
+command actor-state done =
+  amr-done;
+
+command actor-state transition: (New-state is actor-state) =
+  new amr-transition(New-state);
+
+
+// -- Message dispatching
+command actor-internal wake-up do
+  condition
+    when not self.busy value do
+      self dispatch-next;
+    end
+
+    otherwise do nothing end
+  end
+end
+
+command actor-internal store-message: (Message is actor-message)
+requires
+  new-message :: not (self.mailbox value contains: Message)
+do
+  self.mailbox <- self.mailbox value append: Message;
+end
+
+command actor-internal select-message do
+  let State = self.state value;
+  let Mailbox = self.mailbox value;
+  let Message = Mailbox find-first: (State accepts: _);
+  Message;
+end
+
+command actor-internal dispatch-next do
+  self.busy <- true;
+  let Selected = self select-message;
+  condition
+    when Selected is error do
+      self.busy <- false;
+    end
+
+    when Selected is ok do
+      let Message = Selected value;
+      let Mailbox = self.mailbox value;
+      self.mailbox <- Mailbox remove-if: { X in X =:= Message };
+      self handle: Message;
+      self dispatch-next;
+    end
+  end
+end
+
+
+// -- Handling messages
+command actor-internal handle: Message do
+  let Result = self.state value handle: Message;
+  self handle-result: Result;
+end
+
+command actor-internal handle-result: amr-done do
+  nothing;
+end
+
+command actor-internal handle-result: (R is amr-transition) do
+  self.state <- R.new-state;
+end

--- a/stdlib/crochet.concurrency/source/event-stream.crochet
+++ b/stdlib/crochet.concurrency/source/event-stream.crochet
@@ -1,0 +1,119 @@
+% crochet
+
+singleton internal-event-stream;
+protect global internal-event-stream with internal;
+protect type internal-event-stream with internal;
+
+abstract event-stream;
+
+type event-stream-listener(stream is event-stream);
+
+type subscriber(block is (A -> nothing));
+
+type base-event-stream(
+  subscribers is cell<list<subscriber>>
+) is event-stream;
+
+type foldable-event-stream(
+  source is event-stream,
+  state is cell<B>,
+  fold is ((foldable-event-stream-state, A) -> event-publication<B>),
+  reference is subscriber,
+  output is event-stream
+) is event-stream;
+
+type foldable-event-stream-state(state is B);
+
+abstract event-publication;
+type event-publication-push(value) is event-publication;
+singleton event-publication-skip is event-publication;
+
+
+command #event-stream empty =
+  new base-event-stream(#cell with-value: []);
+
+command event-stream-listener fold-from: Initial with: Combine do
+  self.stream fold-from: Initial with: Combine;
+end
+
+command event-stream fold-from: Initial with: (Combine is ((foldable-event-stream-state, A) -> event-publication<B>)) do
+  let State = #cell with-value: Initial;
+  let Output = #event-stream empty;
+  let Reference = self listener subscribe: (internal-event-stream fold: _ with: Combine state: State publish: Output);
+  new foldable-event-stream(
+    source -> self,
+    state -> State,
+    fold -> Combine,
+    reference -> Reference,
+    output -> Output
+  );
+end
+
+command internal-event-stream fold: A with: Combine state: (State is cell) publish: (Output is event-stream) do
+  let Fold = new foldable-event-stream-state(State value);
+  let Result = Combine(Fold, A);
+  internal-event-stream handle-result: Result state: State publish: Output;
+end
+
+command internal-event-stream handle-result: (R is event-publication-skip) state: _ publish: _ do
+  nothing;
+end
+
+command internal-event-stream handle-result: (R is event-publication-push) state: (State is cell) publish: (Output is event-stream) do
+  State <- R.value;
+  Output publish: R.value;
+end
+
+
+command event-stream map: (F is (A -> B)) do
+  self fold-from: nothing
+       with: { State, A in State push: F(A) };
+end
+
+
+command event-stream keep-if: (F is (A -> boolean)) do
+  self fold-from: nothing with: (internal-event-stream fold: _ do-filter: _ with: F);
+end
+
+command internal-event-stream fold: S do-filter: A with: F do
+  condition
+    when F(A) => S push: A;
+    otherwise => S skip;
+  end
+end
+
+command foldable-event-stream-state state = self.state;
+command foldable-event-stream-state skip = event-publication-skip;
+command foldable-event-stream-state push: Value = new event-publication-push(Value);
+
+
+command base-event-stream listener =
+  new event-stream-listener(self);
+
+command foldable-event-stream listener =
+  self.output listener;
+
+
+command base-event-stream publish: Value do
+  for Subscriber in self.subscribers value do
+    Subscriber.block(Value);
+  end
+  self;
+end
+
+
+command event-stream-listener subscribe: (Block is (A -> nothing)) do
+  let Subscriber = new subscriber(Block capture);
+  self.stream.subscribers <- self.stream.subscribers value append: Subscriber;
+  Subscriber;
+end
+
+command event-stream unsubscribe: (Subscriber is subscriber)
+requires
+  has-subscriber :: self.stream.subscribers value contains: Subscriber
+do
+  self.stream.subscribers <- self.stream.subscribers value remove-if: { X in X =:= Subscriber };
+  self;
+end
+
+

--- a/stdlib/crochet.concurrency/source/internal.crochet
+++ b/stdlib/crochet.concurrency/source/internal.crochet
@@ -1,0 +1,7 @@
+% crochet
+
+singleton internal;
+capability internal;
+
+protect global internal with internal;
+protect type internal with internal;

--- a/stdlib/crochet.concurrency/source/observable-cell.crochet
+++ b/stdlib/crochet.concurrency/source/observable-cell.crochet
@@ -1,0 +1,74 @@
+% crochet
+
+singleton internal-observable;
+protect global internal-observable with internal;
+protect type internal-observable with internal;
+
+abstract observable-cell;
+
+type mutable-observable-cell(
+  state is cell<A>,
+  stream is event-stream
+) is observable-cell;
+
+type foldable-observable-cell(
+  source is observable-cell<A>,
+  stream is foldable-event-stream
+);
+
+
+
+command #observable-cell with-value: Initial do
+  let State = #cell with-value: Initial;
+  let Stream = #event-stream empty;
+  new mutable-observable-cell(State, Stream);
+end
+
+
+command observable-cell fold-from: (Initial is B) with: (Combine is ((B, A) -> B)) -> observable-cell<B> do
+  new foldable-observable-cell(
+    self,
+    self stream fold-from: Initial with: Combine
+  );
+end
+
+command observable-cell read-only =
+  self fold-from: self value with: { S, X in S push: X };
+
+command observable-cell map: (F is (A -> B)) =
+  self fold-from: self value with: { S, X in S push: F(X) };
+
+command observable-cell keep-if: (F is (A -> boolean)) initial-value: Initial
+requires
+  acceptable-initial :: F(Initial)
+do
+  let Value = condition
+                when F(self value) => self value;
+                otherwise => Initial;
+              end;
+  self fold-from: Value with: { S, X in
+    condition
+      when F(X) => S push: X;
+      otherwise => S skip;
+    end
+  };
+end
+
+
+command mutable-observable-cell stream =
+  self.stream listener;
+
+command mutable-observable-cell value =
+  self.state value;
+
+command mutable-observable-cell <- Value do
+  self.state <- Value;
+  self.stream publish: Value;
+end
+
+
+command foldable-observable-cell stream =
+  self.stream listener;
+
+command foldable-observable-cell value =
+  self.stream.state value;

--- a/stdlib/crochet.concurrency/source/promise.crochet
+++ b/stdlib/crochet.concurrency/source/promise.crochet
@@ -1,0 +1,73 @@
+% crochet
+
+type deferred(box);
+type promise(deferred is deferred);
+local singleton promise-cancelled;
+
+// -- Deferreds
+command #deferred make =
+  #deferred make: nothing;
+
+command #deferred make: State =
+  new deferred(foreign promise.defer(State));
+
+command deferred is-resolved =
+  foreign promise.is-resolved(self.box);
+
+command deferred is-cancelled =
+  foreign promise.is-cancelled(self.box);
+
+command deferred cancel do
+  foreign promise.cancel(self.box, promise-cancelled);
+  self;
+end
+
+command deferred resolve: Value do
+  foreign promise.resolve(self.box, Value);
+  self;
+end
+
+command deferred reject: Value do
+  foreign promise.reject(self.box, Value);
+  self;
+end
+
+command deferred promise =
+  new promise(self);
+
+
+// -- Promises
+command promise on-resolved: (F is (A -> promise<B, D>))
+                on-rejected: (G is (C -> promise<B, D>))
+                on-cancelled: (H is (() -> promise<B, D>))
+        -> promise<B, D>
+do
+  let Resolved = { X in
+    let P = F(X);
+    assert P is promise;
+    P.deferred.box;  
+  };
+  let Rejected = { X in
+    let P = 
+      condition
+        when X is promise-cancelled => H();
+        otherwise => G(X);
+      end;
+    assert P is promise;
+    P.deferred.box;
+  };
+  foreign promise.then(self.deferred.box, Resolved capture, Rejected capture);
+  new promise(self.deferred);
+end
+
+command promise on-resolved: F =
+  self on-resolved: F on-rejected: { _ in self } on-cancelled: { self };
+
+command promise on-rejected: F =
+  self on-resolved: { _ in self } on-rejected: F on-cancelled: { self};
+
+command promise on-cancelled: F =
+  self on-resolved: { _ in self } on-rejected: { _ in self } on-cancelled: F;
+
+command promise wait =
+  foreign promise.wait(self.deferred.box);

--- a/stdlib/crochet.concurrency/source/timer.crochet
+++ b/stdlib/crochet.concurrency/source/timer.crochet
@@ -1,0 +1,26 @@
+% crochet
+
+open crochet.time;
+
+singleton timer;
+
+effect timer with
+  sleep(time is duration);
+end
+
+
+command timer sleep: (Time is duration) =
+  perform timer.sleep(Time);
+
+// TODO: make it into proper capabilities
+command timer with-real-timer: (Block is (() -> A)) -> A do
+  handle
+    Block();
+  with
+    on timer.sleep(Time) do
+      let Deferred = #deferred make;
+      foreign timer.wait(Time to-milliseconds, { Deferred resolve: nothing } capture);
+      continue with Deferred promise;
+    end
+  end
+end

--- a/tests/vm-tests/crochet.json
+++ b/tests/vm-tests/crochet.json
@@ -16,7 +16,8 @@
     "crochet.parsing.combinators",
     "crochet.random",
     "crochet.text.parsing.lingua",
-    "crochet.time"
+    "crochet.time",
+    "crochet.concurrency"
   ],
   "sources": [
     "types-before.crochet",


### PR DESCRIPTION
This adds a minimal set of concurrency primitives which have been useful in building the Crochet Launcher. There needs to be some more work on formalising them and specifying a more well-rounded API.