### PR TITLE
Rename `float` type so it is explicit about the size limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
-- Changed `crochet.debug`'s API to require tags for all logging entries (required for proper tracing).
+- Changed `crochet.debug`'s API to require tags for all logging entries (required for proper tracing);
+
+- Renamed `float` to `float-64bit`, and FFI's `float` to `float_64`, to make it more explicit that these are sized types - [#50](https://github.com/qteatime/crochet/pull/50).
 
 ### Added
 
@@ -33,11 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for sealing and unsealing types through `unknown`;
 
-- Added Documentation section to launcher, which exposes the command line `docs` command in the launcher as well.
+- Added Documentation section to launcher, which exposes the command line `docs` command in the launcher as well;
+
+- Added basic support for concurrency - [#49](https://github.com/qteatime/crochet/pull/49).
 
 ### Fixed
 
-- Types and traits can now be defined out of order/circularly within a package - [#47](https://github.com/qteatime/crochet/pull/47);
+- Capabilities, types and traits can now be defined out of order/circularly within a package - [#47](https://github.com/qteatime/crochet/pull/47), [#48](https://github.com/qteatime/crochet/pull/48);
 
 - Improved launcher's design---playground is now more responsive;
 

--- a/examples/node/maze/maze-generation.crochet
+++ b/examples/node/maze/maze-generation.crochet
@@ -26,8 +26,8 @@ command point move: south = new point(self.X, self.Y + 1);
 command point move: west  = new point(self.X - 1, self.Y);
 
 command point distance-to: (P is point) do
-  let X = (P.X - self.X) as float;
-  let Y = (P.Y - self.Y) as float;
+  let X = (P.X - self.X) as float-64bit-64bit;
+  let Y = (P.Y - self.Y) as float-64bit;
   ((X ** 2) + (Y ** 2)) sqrt;
 end
 

--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -100,7 +100,7 @@ export class ForeignInterface {
     return Values.make_integer(this.#universe, x);
   }
 
-  float(x: number) {
+  float_64(x: number) {
     return Values.make_float(this.#universe, x);
   }
 

--- a/source/vm/boot.ts
+++ b/source/vm/boot.ts
@@ -123,7 +123,7 @@ export function make_universe() {
   );
   const Float = new CrochetType(
     null,
-    "float",
+    "float-64bit",
     "",
     Fractional,
     [],
@@ -365,7 +365,7 @@ export function make_universe() {
   world.native_types.define("crochet.core/core.numeric", Numeric);
   world.native_types.define("crochet.core/core.fractional", Fractional);
   world.native_types.define("crochet.core/core.integral", Integral);
-  world.native_types.define("crochet.core/core.float", Float);
+  world.native_types.define("crochet.core/core.float-64bit", Float);
   world.native_types.define("crochet.core/core.integer", Integer);
   world.native_types.define(
     "crochet.core/core.unsafe-arbitrary-text",

--- a/source/vm/boot.ts
+++ b/source/vm/boot.ts
@@ -121,7 +121,7 @@ export function make_universe() {
     false,
     null
   );
-  const Float = new CrochetType(
+  const Float_64 = new CrochetType(
     null,
     "float-64bit",
     "",
@@ -365,7 +365,7 @@ export function make_universe() {
   world.native_types.define("crochet.core/core.numeric", Numeric);
   world.native_types.define("crochet.core/core.fractional", Fractional);
   world.native_types.define("crochet.core/core.integral", Integral);
-  world.native_types.define("crochet.core/core.float-64bit", Float);
+  world.native_types.define("crochet.core/core.float-64bit", Float_64);
   world.native_types.define("crochet.core/core.integer", Integer);
   world.native_types.define(
     "crochet.core/core.unsafe-arbitrary-text",
@@ -408,7 +408,7 @@ export function make_universe() {
     True,
     False,
     Integer,
-    Float,
+    Float_64: Float_64,
     UnsafeArbitraryText,
     UntrustedText,
     Text,

--- a/source/vm/intrinsics.ts
+++ b/source/vm/intrinsics.ts
@@ -949,7 +949,7 @@ export class Universe {
       True: CrochetType;
       False: CrochetType;
       Integer: CrochetType;
-      Float: CrochetType;
+      Float_64: CrochetType;
       UnsafeArbitraryText: CrochetType;
       UntrustedText: CrochetType;
       Text: CrochetType;
@@ -989,7 +989,7 @@ export class Universe {
         types.Integer,
         BigInt(i)
       );
-      this.float_cache[i] = new CrochetValue(Tag.FLOAT_64, types.Float, i);
+      this.float_cache[i] = new CrochetValue(Tag.FLOAT_64, types.Float_64, i);
     }
   }
 
@@ -1001,11 +1001,11 @@ export class Universe {
     }
   }
 
-  make_float(x: number) {
+  make_float_64(x: number) {
     if (Number.isInteger(x) && x >= 0 && x < this.float_cache.length) {
       return this.float_cache[x];
     } else {
-      return new CrochetValue(Tag.FLOAT_64, this.types.Float, x);
+      return new CrochetValue(Tag.FLOAT_64, this.types.Float_64, x);
     }
   }
 
@@ -1066,7 +1066,7 @@ function cmap_get_primitive(v: CrochetValue): Primitive {
 export class CMap<V> {
   private _types: {
     integer: CrochetType;
-    float: CrochetType;
+    float_64: CrochetType;
     true: CrochetValue;
     false: CrochetValue;
     nothing: CrochetValue;
@@ -1179,8 +1179,8 @@ export class CMap<V> {
         break;
 
       case "number":
-        if (this._types.float) break;
-        this._types.float = value.type;
+        if (this._types.float_64) break;
+        this._types.float_64 = value.type;
         break;
 
       case "boolean":
@@ -1207,7 +1207,7 @@ export class CMap<V> {
     } else {
       switch (typeof key) {
         case "number":
-          return new CrochetValue(Tag.FLOAT_64, this._types.float, key);
+          return new CrochetValue(Tag.FLOAT_64, this._types.float_64, key);
         case "bigint":
           return new CrochetValue(Tag.INTEGER, this._types.integer, key);
         case "boolean": {

--- a/source/vm/primitives/values.ts
+++ b/source/vm/primitives/values.ts
@@ -38,7 +38,7 @@ export function make_integer(universe: Universe, x: bigint) {
 }
 
 export function make_float(universe: Universe, x: number) {
-  return universe.make_float(x);
+  return universe.make_float_64(x);
 }
 
 export function make_dynamic_text(universe: Universe, x: string) {

--- a/stdlib/crochet.core/native/action.ts
+++ b/stdlib/crochet.core/native/action.ts
@@ -1,7 +1,7 @@
 import type { ForeignInterface } from "../../../build/crochet";
 
 export default (ffi: ForeignInterface) => {
-  ffi.defun("action.score", (x) => ffi.float(ffi.action_choice(x).score));
+  ffi.defun("action.score", (x) => ffi.float_64(ffi.action_choice(x).score));
   ffi.defun("action.action", (x) => ffi.action_choice(x).action);
   ffi.defun("action.fired-for", (action, v) => {
     return ffi.boolean(ffi.action_fired(action, v));

--- a/stdlib/crochet.core/native/floats.ts
+++ b/stdlib/crochet.core/native/floats.ts
@@ -1,95 +1,97 @@
 import type { ForeignInterface } from "../../../build/crochet";
 
 export default (ffi: ForeignInterface) => {
-  const nan = ffi.float(NaN);
-  const inf = ffi.float(Number.POSITIVE_INFINITY);
-  const ninf = ffi.float(Number.NEGATIVE_INFINITY);
+  const nan = ffi.float_64(NaN);
+  const inf = ffi.float_64(Number.POSITIVE_INFINITY);
+  const ninf = ffi.float_64(Number.NEGATIVE_INFINITY);
 
   // Constants & Tests
-  ffi.defun("float.nan", () => nan);
+  ffi.defun("float-64.nan", () => nan);
 
-  ffi.defun("float.is-nan", (x) =>
+  ffi.defun("float-64.is-nan", (x) =>
     ffi.boolean(Number.isNaN(ffi.float_to_number(x)))
   );
 
-  ffi.defun("float.is-finite", (x) =>
+  ffi.defun("float-64.is-finite", (x) =>
     ffi.boolean(Number.isFinite(ffi.float_to_number(x)))
   );
 
-  ffi.defun("float.infinity", () => inf);
+  ffi.defun("float-64.infinity", () => inf);
 
-  ffi.defun("float.negative-infinity", () => ninf);
+  ffi.defun("float-64.negative-infinity", () => ninf);
 
-  ffi.defun("float.trunc", (x) =>
-    ffi.float(Math.trunc(ffi.float_to_number(x)))
+  ffi.defun("float-64.trunc", (x) =>
+    ffi.float_64(Math.trunc(ffi.float_to_number(x)))
   );
 
-  ffi.defun("float.floor", (x) =>
-    ffi.float(Math.floor(ffi.float_to_number(x)))
+  ffi.defun("float-64.floor", (x) =>
+    ffi.float_64(Math.floor(ffi.float_to_number(x)))
   );
 
-  ffi.defun("float.ceil", (x) => ffi.float(Math.ceil(ffi.float_to_number(x))));
+  ffi.defun("float-64.ceil", (x) =>
+    ffi.float_64(Math.ceil(ffi.float_to_number(x)))
+  );
 
-  ffi.defun("float.round", (x) =>
-    ffi.float(Math.round(ffi.float_to_number(x)))
+  ffi.defun("float-64.round", (x) =>
+    ffi.float_64(Math.round(ffi.float_to_number(x)))
   );
 
   // Arithmetic
-  ffi.defun("float.add", (x, y) =>
-    ffi.float(ffi.float_to_number(x) + ffi.float_to_number(y))
+  ffi.defun("float-64.add", (x, y) =>
+    ffi.float_64(ffi.float_to_number(x) + ffi.float_to_number(y))
   );
 
-  ffi.defun("float.sub", (x, y) =>
-    ffi.float(ffi.float_to_number(x) - ffi.float_to_number(y))
+  ffi.defun("float-64.sub", (x, y) =>
+    ffi.float_64(ffi.float_to_number(x) - ffi.float_to_number(y))
   );
 
-  ffi.defun("float.mul", (x, y) =>
-    ffi.float(ffi.float_to_number(x) * ffi.float_to_number(y))
+  ffi.defun("float-64.mul", (x, y) =>
+    ffi.float_64(ffi.float_to_number(x) * ffi.float_to_number(y))
   );
 
-  ffi.defun("float.div", (x, y) =>
-    ffi.float(ffi.float_to_number(x) / ffi.float_to_number(y))
+  ffi.defun("float-64.div", (x, y) =>
+    ffi.float_64(ffi.float_to_number(x) / ffi.float_to_number(y))
   );
 
-  ffi.defun("float.rem", (x, y) =>
-    ffi.float(ffi.float_to_number(x) % ffi.float_to_number(y))
+  ffi.defun("float-64.rem", (x, y) =>
+    ffi.float_64(ffi.float_to_number(x) % ffi.float_to_number(y))
   );
 
-  ffi.defun("float.power", (x, y) =>
-    ffi.float(ffi.float_to_number(x) ** Number(ffi.integer_to_bigint(y)))
+  ffi.defun("float-64.power", (x, y) =>
+    ffi.float_64(ffi.float_to_number(x) ** Number(ffi.integer_to_bigint(y)))
   );
 
   // Relational
-  ffi.defun("float.eq", (x, y) =>
+  ffi.defun("float-64.eq", (x, y) =>
     ffi.boolean(ffi.float_to_number(x) === ffi.float_to_number(y))
   );
 
-  ffi.defun("float.neq", (x, y) =>
+  ffi.defun("float-64.neq", (x, y) =>
     ffi.boolean(ffi.float_to_number(x) !== ffi.float_to_number(y))
   );
 
-  ffi.defun("float.lt", (x, y) =>
+  ffi.defun("float-64.lt", (x, y) =>
     ffi.boolean(ffi.float_to_number(x) < ffi.float_to_number(y))
   );
 
-  ffi.defun("float.lte", (x, y) =>
+  ffi.defun("float-64.lte", (x, y) =>
     ffi.boolean(ffi.float_to_number(x) <= ffi.float_to_number(y))
   );
 
-  ffi.defun("float.gt", (x, y) =>
+  ffi.defun("float-64.gt", (x, y) =>
     ffi.boolean(ffi.float_to_number(x) > ffi.float_to_number(y))
   );
 
-  ffi.defun("float.gte", (x, y) =>
+  ffi.defun("float-64.gte", (x, y) =>
     ffi.boolean(ffi.float_to_number(x) >= ffi.float_to_number(y))
   );
 
   // Conversion
-  ffi.defun("float.to-integer", (x) => {
+  ffi.defun("float-64.to-integer", (x) => {
     return ffi.integer(BigInt(ffi.float_to_number(x)));
   });
 
-  ffi.defun("float.parse", (x0) => {
+  ffi.defun("float-64.parse", (x0) => {
     const x1 = ffi.text_to_string(x0).trim();
     if (x1 === "") {
       return ffi.nothing;
@@ -102,12 +104,12 @@ export default (ffi: ForeignInterface) => {
           return ffi.nothing;
         }
       } else {
-        return ffi.float(x2);
+        return ffi.float_64(x2);
       }
     }
   });
 
-  ffi.defun("float.to-text", (x0) => {
+  ffi.defun("float-64.to-text", (x0) => {
     return ffi.text(ffi.float_to_number(x0).toString());
   });
 };

--- a/stdlib/crochet.core/native/integer.ts
+++ b/stdlib/crochet.core/native/integer.ts
@@ -52,8 +52,8 @@ export default (ffi: ForeignInterface) => {
   );
 
   // Conversion
-  ffi.defun("integer.to-float", (x) => {
-    return ffi.float(Number(ffi.integer_to_bigint(x)));
+  ffi.defun("integer.to-float-64", (x) => {
+    return ffi.float_64(Number(ffi.integer_to_bigint(x)));
   });
 
   ffi.defun("integer.parse", (x0) => {

--- a/stdlib/crochet.core/readme.md
+++ b/stdlib/crochet.core/readme.md
@@ -34,7 +34,7 @@ Within [type:numeric] we have two broader categories of types:
 
 - [type:fractional] is the base type for all numbers that may contain
   fractions, such as `1234.5`. There's only one fractional type that
-  `Core` provides: [type:float]. This is a 64-bit IEEE-754 floating
+  `Core` provides: [type:float-64bit]. This is a 64-bit IEEE-754 floating
   point value—it supports representing many numbers, but as
   approximations. And these approximations become less and less
   precise as the number grows bigger, just so we can guarantee that

--- a/stdlib/crochet.core/source/0-types.crochet
+++ b/stdlib/crochet.core/source/0-types.crochet
@@ -89,7 +89,7 @@ type numeric = foreign core.numeric;
 type fractional = foreign core.fractional;
 
 /// The type for IEEE-754 64-bit floating point numbers.
-type float = foreign core.float;
+type float-64bit = foreign core.float-64bit;
 
 /// The base type for integral numbers.
 ///

--- a/stdlib/crochet.core/source/debug/coercions.crochet
+++ b/stdlib/crochet.core/source/debug/coercions.crochet
@@ -11,9 +11,9 @@ implement to-doc-unit for integer;
 command integer as doc-unit =
   new doc-pixels(self);
 
-implement to-doc-unit for float;
-/// Coerces a float to a doc-percent.
-command float as doc-unit =
+implement to-doc-unit for float-64bit;
+/// Coerces a float-64bit to a doc-percent.
+command float-64bit as doc-unit =
   new doc-percent(self);
 
 implement to-doc-unit for nothing;
@@ -26,10 +26,10 @@ command nothing as doc-unit =
 command integer as doc-pixels =
   new doc-pixels(self);
 
-command float as doc-percent =
+command float-64bit as doc-percent =
   new doc-percent(self);
 
-command float as doc-em =
+command float-64bit as doc-em =
   new doc-em(self);
 
 implement to-doc-font-family for doc-font-family;

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -226,7 +226,7 @@ command debug-serialisation for: (X is doc-percent) =
 command debug-serialisation for: (X is doc-pixels) =
   [
     unit -> "pixel",
-    value -> X.value as float,
+    value -> X.value as float-64bit,
   ];
 
 command debug-serialisation for: doc-unit-unset =
@@ -347,8 +347,8 @@ command debug-serialisation for: doc-colour-inherit =
 command debug-serialisation for: (X is doc-colour-rgba) =
   [
     tag -> "rgba",
-    red -> X.red as float,
-    green -> X.green as float,
-    blue -> X.blue as float,
-    alpha -> X.alpha as float,
+    red -> X.red as float-64bit,
+    green -> X.green as float-64bit,
+    blue -> X.blue as float-64bit,
+    alpha -> X.alpha as float-64bit,
   ];

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -57,10 +57,10 @@ singleton doc-unit-unset is doc-unit;
 type doc-pixels(value is integer) is doc-unit;
 
 /// Value in percentage (context-dependent).
-type doc-percent(value is float) is doc-unit;
+type doc-percent(value is float-64bit) is doc-unit;
 
 /// Value in em units.
-type doc-em(value is float) is doc-unit;
+type doc-em(value is float-64bit) is doc-unit;
 
 /// A 2d point of doc units.
 type doc-point2d(x is doc-unit, y is doc-unit);

--- a/stdlib/crochet.core/source/numeric/arithmetic.crochet
+++ b/stdlib/crochet.core/source/numeric/arithmetic.crochet
@@ -1,7 +1,7 @@
 % crochet
 
 implement arithmetic for integer;
-implement arithmetic for float;
+implement arithmetic for float-64bit;
 
 // # Integers
 
@@ -98,8 +98,8 @@ end
 
 // # Floating points
 /// Arithmetic addition for floats
-command (X is float) + (Y is float) =
-  foreign float.add(X, Y)
+command (X is float-64bit) + (Y is float-64bit) =
+  foreign float-64.add(X, Y)
 test
   assert (0.0 + 1.0) =:= 1.0;
   assert (0.0 + 1.0) =:= 1.0;
@@ -109,8 +109,8 @@ test
 end
 
 /// Arithmetic subtraction for floats
-command (X is float) - (Y is float) =
-  foreign float.sub(X, Y)
+command (X is float-64bit) - (Y is float-64bit) =
+  foreign float-64.sub(X, Y)
 test
   assert (0.0 - 0.0) =:= 0.0;
   assert (0.0 - 1.0) =:= -1.0;
@@ -120,8 +120,8 @@ test
 end
 
 /// Arithmetic multiplication for floats
-command (X is float) * (Y is float) =
-  foreign float.mul(X, Y)
+command (X is float-64bit) * (Y is float-64bit) =
+  foreign float-64.mul(X, Y)
 test
   assert (0.0 * 0.0) =:= 0.0;
   assert (0.0 * 1.0) =:= 0.0;
@@ -132,11 +132,11 @@ test
 end
 
 /// Arithmetic division for floats
-command (X is float) / (Y is float)
+command (X is float-64bit) / (Y is float-64bit)
 // Technically, IEEE754 allows division by zero, but we choose to be
 // consistent with the other numeric types in Crochet instead
 requires non-zero-divisor :: Y =/= 0.0
-  = foreign float.div(X, Y)
+  = foreign float-64.div(X, Y)
 test
   assert (4.0 / 2.0) =:= 2.0;
   assert (3.0 / 2.0) =:= 1.5;
@@ -146,7 +146,7 @@ test
 end
 
 /// Truncating arithmetic division for floats
-command (X is float) divided-by: (Y is float)
+command (X is float-64bit) divided-by: (Y is float-64bit)
 requires non-zero-divisor :: Y =/= 0.0 do
   (X / Y) truncate;
 test
@@ -159,9 +159,9 @@ test
 end
 
 /// Remainder of an arithmetic division for floats
-command (X is float) % (Y is float)
+command (X is float-64bit) % (Y is float-64bit)
 requires non-zero-divisor :: Y =/= 0.0
-  = foreign float.rem(X, Y)
+  = foreign float-64.rem(X, Y)
 test
   assert (4.0 % 2.0) =:= 0.0;
   assert (3.0 % 2.0) =:= 1.0;
@@ -173,7 +173,7 @@ end
 
 /// Convenience function for getting the quotient and remainder
 /// of a division for floats
-command (X is float) divide-by-with-remainder: (Y is float) do
+command (X is float-64bit) divide-by-with-remainder: (Y is float-64bit) do
   [
     quotient -> X divided-by: Y,
     remainder -> X % Y,
@@ -186,9 +186,9 @@ test
 end
 
 /// Arithmetic exponentiation for floats
-command (X is float) ** (P is integer)
+command (X is float-64bit) ** (P is integer)
 requires positive-exponent :: P >= 0
-  = foreign float.power(X, P)
+  = foreign float-64.power(X, P)
 test
   assert (1.0 ** 0) =:= 1.0;
   assert (0.0 ** 0) =:= 1.0;
@@ -201,25 +201,25 @@ end
 // Arithmetic tower
 
 /// Addition of mixed numbers.
-command (X is integer) + (Y is float) = (X as float) + Y;
-command (X is float) + (Y is integer) = X + (Y as float);
+command (X is integer) + (Y is float-64bit) = (X as float-64bit) + Y;
+command (X is float-64bit) + (Y is integer) = X + (Y as float-64bit);
 
 /// Subtraction of mixed numbers.
-command (X is integer) - (Y is float) = (X as float) - Y;
-command (X is float) - (Y is integer) = X - (Y as float);
+command (X is integer) - (Y is float-64bit) = (X as float-64bit) - Y;
+command (X is float-64bit) - (Y is integer) = X - (Y as float-64bit);
 
 /// Multiplication of mixed numbers.
-command (X is integer) * (Y is float) = (X as float) * Y;
-command (X is float) * (Y is integer) = X * (Y as float);
+command (X is integer) * (Y is float-64bit) = (X as float-64bit) * Y;
+command (X is float-64bit) * (Y is integer) = X * (Y as float-64bit);
 
 /// Division of mixed numbers.
-command (X is integer) / (Y is float) = (X as float) / Y;
-command (X is float) / (Y is integer) = X / (Y as float);
+command (X is integer) / (Y is float-64bit) = (X as float-64bit) / Y;
+command (X is float-64bit) / (Y is integer) = X / (Y as float-64bit);
 
 /// Floating point division of integers.
-command (X is integer) / (Y is integer) = (X as float) / (Y as float);
+command (X is integer) / (Y is integer) = (X as float-64bit) / (Y as float-64bit);
 
 /// Modulo of mixed numbers.
-command (X is integer) % (Y is float) = (X as float) % Y;
-command (X is float) % (Y is integer) = X % (Y as float);
+command (X is integer) % (Y is float-64bit) = (X as float-64bit) % Y;
+command (X is float-64bit) % (Y is integer) = X % (Y as float-64bit);
 

--- a/stdlib/crochet.core/source/numeric/equality.crochet
+++ b/stdlib/crochet.core/source/numeric/equality.crochet
@@ -1,7 +1,7 @@
 % crochet
 
 implement equality for integer;
-implement equality for float;
+implement equality for float-64bit;
 
 /// True if two integers are equal.
 command integer === (That is integer)
@@ -16,7 +16,7 @@ end
 ///
 /// Note that we follow IEEE-754, so NaNs are unordered
 /// and therefore never equal.
-command float === (That is float)
+command float-64bit === (That is float-64bit)
   = self =:= That
 test
   assert 0.0 === 0.0;
@@ -24,41 +24,41 @@ test
   assert not (0.1 === 0.0);
   assert not (1.0 === -1.0);
 
-  assert #float positive-infinity === #float positive-infinity;
-  assert not (#float positive-infinity === #float negative-infinity);
-  assert not (#float nan === #float nan);
-  assert not (0.0 === #float nan);
+  assert #float-64bit positive-infinity === #float-64bit positive-infinity;
+  assert not (#float-64bit positive-infinity === #float-64bit negative-infinity);
+  assert not (#float-64bit nan === #float-64bit nan);
+  assert not (0.0 === #float-64bit nan);
 end
 
 /// True if two floating point values are not equal.
 ///
 /// Note that we follow IEEE-754, so NaNs are unordered
 /// and therefore never equal.
-command (Self is float) =/= (That is float)
-  = foreign float.neq(Self, That)
+command (Self is float-64bit) =/= (That is float-64bit)
+  = foreign float-64.neq(Self, That)
 test
   assert 0.1 =/= 0.0;
   assert 1.0 =/= -1.0;
-  assert 0.0 =/= #float nan;
+  assert 0.0 =/= #float-64bit nan;
   assert not (0.0 =/= 0.0);
   assert not (0.1 =/= 0.1);
 
-  assert #float nan =/= #float nan;
-  assert not (#float positive-infinity =/= #float positive-infinity);
-  assert not (#float negative-infinity =/= #float negative-infinity);
-  assert #float positive-infinity =/= #float negative-infinity;
+  assert #float-64bit nan =/= #float-64bit nan;
+  assert not (#float-64bit positive-infinity =/= #float-64bit positive-infinity);
+  assert not (#float-64bit negative-infinity =/= #float-64bit negative-infinity);
+  assert #float-64bit positive-infinity =/= #float-64bit negative-infinity;
 end
 
 // -- Equality across the numeric tower
 /// True if two numbers of different types are equal if we convert them to
 /// the lowest common type between them. This is often a lossy conversion.
-command (X is integer) === (Y is float) = (X as float) === Y;
-command (X is float) === (Y is integer) = X === (Y as float);
+command (X is integer) === (Y is float-64bit) = (X as float-64bit) === Y;
+command (X is float-64bit) === (Y is integer) = X === (Y as float-64bit);
 
 /// True if two numbers of different types are not equal if we convert them
 /// to the lowest common type between them. This is often a lossy conversion.
-command (X is integer) =/= (Y is float) = (X as float) =/= Y;
-command (X is float) =/= (Y is integer) = X =/= (Y as float);
+command (X is integer) =/= (Y is float-64bit) = (X as float-64bit) =/= Y;
+command (X is float-64bit) =/= (Y is integer) = X =/= (Y as float-64bit);
 
 test "Numeric equality tower" do
   assert (1.0 === 1);

--- a/stdlib/crochet.core/source/numeric/floating-point.crochet
+++ b/stdlib/crochet.core/source/numeric/floating-point.crochet
@@ -1,34 +1,34 @@
 % crochet
 
 /// True if a floating point value is NaN
-command (X is float) is-nan = foreign float.is-nan(X)
+command (X is float-64bit) is-nan = foreign float-64.is-nan(X)
 test
-  assert #float nan is-nan;
+  assert #float-64bit nan is-nan;
   assert not 1.0 is-nan;
 end
 
 /// True if a floating point value represents a real number.
-command (X is float) is-finite = foreign float.is-finite(X)
+command (X is float-64bit) is-finite = foreign float-64.is-finite(X)
 test
-  assert not #float positive-infinity is-finite;
-  assert not #float negative-infinity is-finite;
+  assert not #float-64bit positive-infinity is-finite;
+  assert not #float-64bit negative-infinity is-finite;
   assert 1.0 is-finite;
 end
 
 /// The special `not a number` representation.
-command #float nan = foreign float.nan()
+command #float-64bit nan = foreign float-64.nan()
 test
-  #float nan;
+  #float-64bit nan;
 end
 
 /// The special positive infinity representation.
-command #float positive-infinity = foreign float.infinity()
+command #float-64bit positive-infinity = foreign float-64.infinity()
 test
-  #float positive-infinity
+  #float-64bit positive-infinity
 end
 
 /// The special negative infinity representation.
-command #float negative-infinity = foreign float.negative-infinity()
+command #float-64bit negative-infinity = foreign float-64.negative-infinity()
 test
-  #float negative-infinity
+  #float-64bit negative-infinity
 end

--- a/stdlib/crochet.core/source/numeric/rounding-strategies.crochet
+++ b/stdlib/crochet.core/source/numeric/rounding-strategies.crochet
@@ -1,9 +1,9 @@
 % crochet
 
-implement rounding-strategies for float;
+implement rounding-strategies for float-64bit;
 
 /// Truncate a floating point number
-command (X is float) truncate = foreign float.trunc(X)
+command (X is float-64bit) truncate = foreign float-64.trunc(X)
 test
   assert 1.3 truncate =:= 1.0;
   assert 1.9 truncate =:= 1.0;
@@ -12,7 +12,7 @@ test
 end
 
 /// Returns the next integer smaller than self
-command (X is float) floor = foreign float.floor(X)
+command (X is float-64bit) floor = foreign float-64.floor(X)
 test
   assert 1.3 floor =:= 1.0;
   assert 1.9 floor =:= 1.0;
@@ -21,7 +21,7 @@ test
 end
 
 /// Returns the next integer larger than self
-command (X is float) ceiling = foreign float.ceil(X)
+command (X is float-64bit) ceiling = foreign float-64.ceil(X)
 test
   assert 1.3 ceiling =:= 2.0;
   assert 1.9 ceiling =:= 2.0;
@@ -30,7 +30,7 @@ test
 end
 
 /// Returns the integer nearest to self
-command (X is float) round = foreign float.round(X)
+command (X is float-64bit) round = foreign float-64.round(X)
 test
   assert 1.3 round =:= 1.0;
   assert 1.9 round =:= 2.0;

--- a/stdlib/crochet.core/source/numeric/total-ordering.crochet
+++ b/stdlib/crochet.core/source/numeric/total-ordering.crochet
@@ -1,7 +1,7 @@
 % crochet
 
 implement total-ordering for integer;
-implement total-ordering for float;
+implement total-ordering for float-64bit;
 
 
 /// Relational less than operator for integers
@@ -46,8 +46,8 @@ end
 
 
 /// Relational less than operator for floats
-command (X is float) < (Y is float) = 
-  foreign float.lt(X, Y)
+command (X is float-64bit) < (Y is float-64bit) = 
+  foreign float-64.lt(X, Y)
 test
   assert 0.0 < 1.0;
   assert -1.0 < 0.0;
@@ -56,8 +56,8 @@ test
 end
 
 /// Relational less than or equal operator for floats (provided for perf)
-command (X is float) <= (Y is float) = 
-  foreign float.lte(X, Y)
+command (X is float-64bit) <= (Y is float-64bit) = 
+  foreign float-64.lte(X, Y)
 test
   assert 0.0 <= 1.0;
   assert -1.0 <= 0.0;
@@ -66,8 +66,8 @@ test
 end
 
 /// Relational greater than operator for floats
-command (X is float) > (Y is float) = 
-  foreign float.gt(X, Y)
+command (X is float-64bit) > (Y is float-64bit) = 
+  foreign float-64.gt(X, Y)
 test
   assert 1.0 > 0.0;
   assert 0.0 > -1.0;
@@ -76,8 +76,8 @@ test
 end
 
 /// Relational greater or equal operator for floats (provided for perf)
-command (X is float) >= (Y is float) = 
-  foreign float.gte(X, Y)
+command (X is float-64bit) >= (Y is float-64bit) = 
+  foreign float-64.gte(X, Y)
 test
   assert 1.0 >= 0.0;
   assert 0.0 >= -1.0;
@@ -88,20 +88,20 @@ end
 
 // # Relational operators across numeric types
 /// True if `X` is less than `Y`.
-command (X is integer) <  (Y is float) = (X as float) < Y;
-command (X is float) <  (Y is integer) = X <  (Y as float);
+command (X is integer) <  (Y is float-64bit) = (X as float-64bit) < Y;
+command (X is float-64bit) <  (Y is integer) = X <  (Y as float-64bit);
 
 /// True if `X` is less or equal to `Y`.
-command (X is integer) <= (Y is float) = (X as float) <= Y;
-command (X is float) <= (Y is integer) = X <= (Y as float);
+command (X is integer) <= (Y is float-64bit) = (X as float-64bit) <= Y;
+command (X is float-64bit) <= (Y is integer) = X <= (Y as float-64bit);
 
 /// True if `X` is greater than `Y`.
-command (X is integer) >  (Y is float) = (X as float) > Y;
-command (X is float) >  (Y is integer) = X >  (Y as float);
+command (X is integer) >  (Y is float-64bit) = (X as float-64bit) > Y;
+command (X is float-64bit) >  (Y is integer) = X >  (Y as float-64bit);
 
 /// True if `X` is greater or equal to `Y`.
-command (X is integer) >= (Y is float) = (X as float) >= Y;
-command (X is float) >= (Y is integer) = X >= (Y as float);
+command (X is integer) >= (Y is float-64bit) = (X as float-64bit) >= Y;
+command (X is float-64bit) >= (Y is integer) = X >= (Y as float-64bit);
 
 
 test "Relational conversions" do

--- a/stdlib/crochet.core/source/traits/conversion.crochet
+++ b/stdlib/crochet.core/source/traits/conversion.crochet
@@ -4,24 +4,24 @@
 ///
 /// The conversion is guaranteed to not lose precision by having a pre-condition
 /// on the range of safe integers that can be converted.
-command integer as float
+command integer as float-64bit
 requires
   within-float-bounds :: (self > -9007199254740992) and (self < 9007199254740992)
 do
-  foreign integer.to-float(self)
+  foreign integer.to-float-64(self)
 test
-  assert (1 as float) =:= 1.0;
-  assert (0 as float) =:= 0.0;
-  assert (-1 as float) =:= -1.0;
+  assert (1 as float-64bit) =:= 1.0;
+  assert (0 as float-64bit) =:= 0.0;
+  assert (-1 as float-64bit) =:= -1.0;
 end
 
 /// Converts a 64-bit floating point to an integer. The floating point
 /// number must be a whole number.
-command float as integer
+command float-64bit as integer
 requires
   integral :: self =:= self truncate
 do
-  foreign float.to-integer(self)
+  foreign float-64.to-integer(self)
 test
   assert (1.0 as integer) =:= 1;
   assert (0.0 as integer) =:= 0;
@@ -71,22 +71,22 @@ end
 
 /// Attempts to parse a piece of text as a floating point number. The
 /// grammar is similar to the JavaScript's floating point grammar.
-command #float try-parse: (X is text) -> result do
-  let Result = foreign float.parse(X);
+command #float-64bit try-parse: (X is text) -> result do
+  let Result = foreign float-64.parse(X);
   condition
     when Result =:= nothing => (#result error: new error-parsing-float(X));
     otherwise => #result ok: Result;
   end
 test
-  assert (#float try-parse: "123").value =:= 123.0;
-  assert (#float try-parse: "123.123").value =:= 123.123;
-  assert (#float try-parse: "-123.0").value =:= -123.0;
-  assert (#float try-parse: "NaN").value is-nan;
-  assert (#float try-parse: "nope") is error;
+  assert (#float-64bit try-parse: "123").value =:= 123.0;
+  assert (#float-64bit try-parse: "123.123").value =:= 123.123;
+  assert (#float-64bit try-parse: "-123.0").value =:= -123.0;
+  assert (#float-64bit try-parse: "NaN").value is-nan;
+  assert (#float-64bit try-parse: "nope") is error;
 end
   
 /// Converts an integer to a piece of trusted text.
 command integer to-text = foreign integer.to-text(self);
 
 /// Converts a floating point number to a piece of trusted text.
-command float to-text = foreign float.to-text(self);
+command float-64bit to-text = foreign float-64.to-text(self);

--- a/stdlib/crochet.core/source/traits/iteration.crochet
+++ b/stdlib/crochet.core/source/traits/iteration.crochet
@@ -111,7 +111,7 @@ end
 
 /// The average of all items in the collection. Every item must implement
 /// [trait:arithmetic].
-command (X has foldable-collection, countable-container) average -> float
+command (X has foldable-collection, countable-container) average -> float-64bit
 requires non-empty :: not X is-empty
 do
   X sum / X count;

--- a/stdlib/crochet.language.json/source/json.crochet
+++ b/stdlib/crochet.language.json/source/json.crochet
@@ -12,7 +12,7 @@ local enum serialisation-mode =
   sm-unsupported;
 
 /// Returns the mode of serialisation for a given value (recursively)
-command #serialisation-mode for: float =
+command #serialisation-mode for: float-64bit =
   sm-trusted;
 
 command #serialisation-mode for: boolean =

--- a/stdlib/crochet.mathematics/native/trigonometry.ts
+++ b/stdlib/crochet.mathematics/native/trigonometry.ts
@@ -1,38 +1,64 @@
 import type { ForeignInterface } from "../../../build/crochet";
 
 export default (ffi: ForeignInterface) => {
-  const pi = ffi.float(Math.PI);
-  const e = ffi.float(Math.E);
+  const pi = ffi.float_64(Math.PI);
+  const e = ffi.float_64(Math.E);
 
-  ffi.defun("float.pi", () => pi);
-  ffi.defun("float.e", () => e);
+  ffi.defun("float-64.pi", () => pi);
+  ffi.defun("float-64.e", () => e);
 
-  ffi.defun("float.sin", (x) => ffi.float(Math.sin(ffi.float_to_number(x))));
-  ffi.defun("float.sinh", (x) => ffi.float(Math.sinh(ffi.float_to_number(x))));
-  ffi.defun("float.asin", (x) => ffi.float(Math.asin(ffi.float_to_number(x))));
-  ffi.defun("float.asinh", (x) =>
-    ffi.float(Math.asinh(ffi.float_to_number(x)))
+  ffi.defun("float-64.sin", (x) =>
+    ffi.float_64(Math.sin(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.sinh", (x) =>
+    ffi.float_64(Math.sinh(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.asin", (x) =>
+    ffi.float_64(Math.asin(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.asinh", (x) =>
+    ffi.float_64(Math.asinh(ffi.float_to_number(x)))
   );
 
-  ffi.defun("float.cos", (x) => ffi.float(Math.cos(ffi.float_to_number(x))));
-  ffi.defun("float.cosh", (x) => ffi.float(Math.cosh(ffi.float_to_number(x))));
-  ffi.defun("float.acos", (x) => ffi.float(Math.acos(ffi.float_to_number(x))));
-  ffi.defun("float.acosh", (x) =>
-    ffi.float(Math.acosh(ffi.float_to_number(x)))
+  ffi.defun("float-64.cos", (x) =>
+    ffi.float_64(Math.cos(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.cosh", (x) =>
+    ffi.float_64(Math.cosh(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.acos", (x) =>
+    ffi.float_64(Math.acos(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.acosh", (x) =>
+    ffi.float_64(Math.acosh(ffi.float_to_number(x)))
   );
 
-  ffi.defun("float.tan", (x) => ffi.float(Math.tan(ffi.float_to_number(x))));
-  ffi.defun("float.tanh", (x) => ffi.float(Math.tanh(ffi.float_to_number(x))));
-  ffi.defun("float.atan", (x) => ffi.float(Math.atan(ffi.float_to_number(x))));
-  ffi.defun("float.atanh", (x) =>
-    ffi.float(Math.atanh(ffi.float_to_number(x)))
+  ffi.defun("float-64.tan", (x) =>
+    ffi.float_64(Math.tan(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.tanh", (x) =>
+    ffi.float_64(Math.tanh(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.atan", (x) =>
+    ffi.float_64(Math.atan(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.atanh", (x) =>
+    ffi.float_64(Math.atanh(ffi.float_to_number(x)))
   );
 
-  ffi.defun("float.cbrt", (x) => ffi.float(Math.cbrt(ffi.float_to_number(x))));
-  ffi.defun("float.sqrt", (x) => ffi.float(Math.sqrt(ffi.float_to_number(x))));
-  ffi.defun("float.clz32", (x) =>
-    ffi.float(Math.clz32(ffi.float_to_number(x)))
+  ffi.defun("float-64.cbrt", (x) =>
+    ffi.float_64(Math.cbrt(ffi.float_to_number(x)))
   );
-  ffi.defun("float.exp", (x) => ffi.float(Math.exp(ffi.float_to_number(x))));
-  ffi.defun("float.log", (x) => ffi.float(Math.log(ffi.float_to_number(x))));
+  ffi.defun("float-64.sqrt", (x) =>
+    ffi.float_64(Math.sqrt(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.clz32", (x) =>
+    ffi.float_64(Math.clz32(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.exp", (x) =>
+    ffi.float_64(Math.exp(ffi.float_to_number(x)))
+  );
+  ffi.defun("float-64.log", (x) =>
+    ffi.float_64(Math.log(ffi.float_to_number(x)))
+  );
 };

--- a/stdlib/crochet.mathematics/source/trigonometry.crochet
+++ b/stdlib/crochet.mathematics/source/trigonometry.crochet
@@ -1,105 +1,105 @@
 % crochet
 
 /// The ratio of a circle's circumference to its diameter (approximately 3.14).
-command #float pi = foreign float.pi()
+command #float-64bit pi = foreign float-64.pi()
 test
-  assert #float pi === 3.141592653589793;
+  assert #float-64bit pi === 3.141592653589793;
 end
 
 /// The sine of `X`.
-command (X is float) sin = foreign float.sin(X)
+command (X is float-64bit) sin = foreign float-64.sin(X)
 test
   assert 2.0 sin === 0.9092974268256817;
 end
 
 /// The hyperbolic sine of `X`.
-command (X is float) sinh = foreign float.sinh(X)
+command (X is float-64bit) sinh = foreign float-64.sinh(X)
 test
   assert 2.0 sinh === 3.626860407847019;
 end
 
 /// The arcsine of `X`.
-command (X is float) asin = foreign float.asin(X)
+command (X is float-64bit) asin = foreign float-64.asin(X)
 test
   assert 1.0 asin === 1.5707963267948966;
 end
 
 /// The hyperbolic arcsine of `X`.
-command (X is float) asinh = foreign float.asinh(X)
+command (X is float-64bit) asinh = foreign float-64.asinh(X)
 test
   assert 2.0 asinh === 1.4436354751788103;
 end
 
 /// The cosine of `X`.
-command (X is float) cos = foreign float.cos(X)
+command (X is float-64bit) cos = foreign float-64.cos(X)
 test
   assert 2.0 cos === -0.4161468365471424;
 end
 
 /// The hyperbolic cosine of `X`.
-command (X is float) cosh = foreign float.cosh(X)
+command (X is float-64bit) cosh = foreign float-64.cosh(X)
 test
   assert 2.0 cosh === 3.7621956910836314;
 end
 
 /// The arccosine of `X`.
-command (X is float) acos = foreign float.acos(X)
+command (X is float-64bit) acos = foreign float-64.acos(X)
 test
   assert 0.5 acos === 1.0471975511965979;
 end
 
 /// The hyperbolic arccosine of `X`.
-command (X is float) acosh = foreign float.acosh(X)
+command (X is float-64bit) acosh = foreign float-64.acosh(X)
 test
   assert 2.0 acosh === 1.3169578969248166;
 end
 
 /// The tangent of `X`.
-command (X is float) tan = foreign float.tan(X)
+command (X is float-64bit) tan = foreign float-64.tan(X)
 test
   assert 2.0 tan === -2.185039863261519;
 end
 
 /// The arctangent of `X`.
-command (X is float) atan = foreign float.atan(X)
+command (X is float-64bit) atan = foreign float-64.atan(X)
 test
   assert 2.0 atan === 1.1071487177940904;
 end
 
 /// The hyperbolic arctangent of `X`.
-command (X is float) atanh = foreign float.atanh(X)
+command (X is float-64bit) atanh = foreign float-64.atanh(X)
 test
   assert 0.5 atanh === 0.5493061443340548;
 end
 
 /// The hyperbolic tangent of `X`.
-command (X is float) tanh = foreign float.tanh(X)
+command (X is float-64bit) tanh = foreign float-64.tanh(X)
 test
   assert 2.0 tanh === 0.9640275800758169;
 end
 
 /// Converts from degrees to radians.
-command float degrees-to-radians =
-  self * (#float pi / 180.0)
+command float-64bit degrees-to-radians =
+  self * (#float-64bit pi / 180.0)
 test
   assert 45.0 degrees-to-radians === 0.7853981633974483;
 end
 
 /// Converts from radians to degrees.
-command float radians-to-degrees =
-  self / (#float pi / 180.0)
+command float-64bit radians-to-degrees =
+  self / (#float-64bit pi / 180.0)
 test
   assert 2.0 radians-to-degrees === 114.59155902616465;
 end
 
 /// The cube root of `X`.
-command (X is float) cbrt = foreign float.cbrt(X)
+command (X is float-64bit) cbrt = foreign float-64.cbrt(X)
 test
   assert 9.0 cbrt === 2.080083823051904;
 end
 
 /// The square root of `X`.
-command (X is float) sqrt = foreign float.sqrt(X)
+command (X is float-64bit) sqrt = foreign float-64.sqrt(X)
 test
   assert 9.0 sqrt === 3.0;
 end

--- a/stdlib/crochet.random/native/xorshift.ts
+++ b/stdlib/crochet.random/native/xorshift.ts
@@ -18,7 +18,7 @@ export default (ffi: ForeignInterface) => {
     const value = rand.random();
     return ffi.record(
       new Map([
-        ["value", ffi.float(value)],
+        ["value", ffi.float_64(value)],
         ["seed", ffi.integer(BigInt(rand.seed))],
         ["inc", ffi.integer(BigInt(rand.inc))],
       ])

--- a/stdlib/crochet.random/source/0-types.crochet
+++ b/stdlib/crochet.random/source/0-types.crochet
@@ -40,7 +40,7 @@ type scored-item(global score is integer, global value);
 /// derived automatically from it.
 trait predictable-rng with
   /// Returns a fractional number from 0 up to (but not including) 1.
-  command Random uniform -> random-next<float>;
+  command Random uniform -> random-next<float-64bit>;
 
   /// Returns an integral number between `Min` and `Max`, inclusive on
   /// both ends.

--- a/stdlib/crochet.random/source/mutable-random.crochet
+++ b/stdlib/crochet.random/source/mutable-random.crochet
@@ -1,7 +1,7 @@
 % crochet
 
 /// Returns a fractional number from 0 up to (but not including) 1.
-command mutable-random uniform -> float do
+command mutable-random uniform -> float-64bit do
   let Result = self.random value uniform;
   self.random <- Result random;
   Result.value

--- a/stdlib/crochet.random/source/xor-shift.crochet
+++ b/stdlib/crochet.random/source/xor-shift.crochet
@@ -3,7 +3,7 @@
 implement predictable-rng for xor-shift;
 
 /// Returns a fractional number from 0 up to (but not including) 1.
-command xor-shift uniform -> random-next<float>
+command xor-shift uniform -> random-next<float-64bit>
 do
   let Result = foreign xorshift.next-uniform(self.seed, self.inc);
   new random-next(Result.value, new xor-shift(Result.seed, Result.inc))

--- a/stdlib/crochet.time/source/duration.crochet
+++ b/stdlib/crochet.time/source/duration.crochet
@@ -229,7 +229,7 @@ command duration to-milliseconds -> integer do
 end
 
 /// Converts a duration to seconds
-command duration to-seconds -> float do
+command duration to-seconds -> float-64bit do
     (self.days * 24 * 60 * 60)
   + (self.hours * 60 * 60)
   + (self.minutes * 60)
@@ -238,7 +238,7 @@ command duration to-seconds -> float do
 end
 
 /// Converts a duration to minutes
-command duration to-minutes -> float do
+command duration to-minutes -> float-64bit do
     (self.days * 24 * 60)
   + (self.hours * 60)
   + (self.minutes)
@@ -247,7 +247,7 @@ command duration to-minutes -> float do
 end
 
 /// Converts a duration to hours
-command duration to-hours -> float do
+command duration to-hours -> float-64bit do
     (self.days * 24)
   + (self.hours)
   + (self.minutes / 60.0)
@@ -256,7 +256,7 @@ command duration to-hours -> float do
 end
 
 /// Converts a duration to days
-command duration to-days -> float do
+command duration to-days -> float-64bit do
     (self.days)
   + (self.hours / 24.0)
   + (self.minutes / (24.0 * 60.0))

--- a/tests/vm-tests/multimethod.crochet
+++ b/tests/vm-tests/multimethod.crochet
@@ -2,8 +2,8 @@
 
 trait spice;
 trait pain;
-implement spice for float;
-implement pain for float;
+implement spice for float-64bit;
+implement pain for float-64bit;
 implement pain for text;
 
 command any multimethod-test-other = "any other";
@@ -14,8 +14,8 @@ command function multimethod-test = "function test";
 command boolean multimethod-test = "boolean test";
 command true multimethod-test = "true test";
 command #integer multimethod-test = "#integer test";
-command (_ is float has pain) multimethod-test-other = "float+pain other";
-command float multimethod-test-other = "float other";
+command (_ is float-64bit has pain) multimethod-test-other = "float-64bit+pain other";
+command float-64bit multimethod-test-other = "float-64bit other";
 command (_ is fractional has pain) multimethod-test-other = "fractional+pain other";
 command (_ has pain) multimethod-test-other = "any+pain other";
 
@@ -31,6 +31,6 @@ test "Multimethod selection and dispatch" do
 
   // Subtyping + traits
   assert 1.0 multimethod-test =:= "any+spice,pain test";
-  assert 1.0 multimethod-test-other =:= "float+pain other";
+  assert 1.0 multimethod-test-other =:= "float-64bit+pain other";
   assert "a" multimethod-test-other =:= "any+pain other";
 end

--- a/tools/launcher/app/source/ui/0-types.crochet
+++ b/tools/launcher/app/source/ui/0-types.crochet
@@ -47,8 +47,8 @@ type reference-env(parent, mapping is cell<map<agata-reference, dom-node>>);
 
 abstract measure;
 type pixels(value is integer) is measure;
-type percent(value is float) is measure;
-type em(value is float) is measure;
+type percent(value is float-64bit) is measure;
+type em(value is float-64bit) is measure;
 
 type gap(horizontal is measure, vertical is measure);
 

--- a/tools/launcher/app/source/ui/measure.crochet
+++ b/tools/launcher/app/source/ui/measure.crochet
@@ -1,9 +1,9 @@
 % crochet
 
 command integer pixels = new pixels(self);
-command float percent = new percent(self);
-command integer percent = new percent(self as float);
-command float em = new em(self);
-command integer em = new em(self as float);
+command float-64bit percent = new percent(self);
+command integer percent = new percent(self as float-64bit);
+command float-64bit em = new em(self);
+command integer em = new em(self as float-64bit);
 
 

--- a/tools/launcher/app/source/ui/widget.crochet
+++ b/tools/launcher/app/source/ui/widget.crochet
@@ -241,8 +241,8 @@ command w-switch otherwise: (Handler is (A -> widget)) =
 implement to-widget for integer;
 command integer as widget = agata-widget text: self to-text;
 
-implement to-widget for float;
-command float as widget = agata-widget text: self to-text;
+implement to-widget for float-64bit;
+command float-64bit as widget = agata-widget text: self to-text;
 
 implement to-widget for text;
 command text as widget = agata-widget text: self;


### PR DESCRIPTION
Non-size-suffixed type names should be reserved for arbitrary-precision types. If a type is bounded to a certain size, this should be reflected in its name. Doing so avoids confusing situations where people may not reason about the information bounds they're encoding in their programs, thus making programs unsafe.

So this patch renames the previous `float` type to `float-64bit`, and all native operations from `float` to some variation of `float-64`.

This fixes #40 