### PR TITLE
Add URL type

### DIFF
--- a/source/crochet/crochet.ts
+++ b/source/crochet/crochet.ts
@@ -105,6 +105,32 @@ export class Crochet {
     readonly signal: ISignal
   ) {}
 
+  get trusted_core() {
+    // TODO: restrict TCB (needs safer native modules support)
+    return new Set([
+      "crochet.codec.basic",
+      "crochet.concurrency",
+      "crochet.core",
+      "crochet.debug",
+      "crochet.debug.tracing",
+      "crochet.language.csv",
+      "crochet.language.json",
+      "crochet.mathematics",
+      "crochet.network.types",
+      "crochet.novella",
+      "crochet.random",
+      "crochet.text.parsing.lingua",
+      "crochet.text.regex",
+      "crochet.time",
+      "crochet.ui.agata",
+      "crochet.wrapper.node.file-system",
+      "crochet.wrapper.node.http",
+      "crochet.wrapper.node.io",
+      "crochet.wrapper.node.os",
+      "crochet.wrapper.node.shell",
+    ]);
+  }
+
   async boot(root: string, target: Package.Target) {
     const pkg = await this.get_package(root);
     const graph = await Package.build_package_graph(

--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -247,8 +247,9 @@ export class ForeignInterface {
   }
 
   unbox_typed<T extends Function>(type: T, x: CrochetValue): T["prototype"] {
-    if (x instanceof type) {
-      return x;
+    const unboxed = Values.unbox(x);
+    if (unboxed instanceof type) {
+      return unboxed;
     } else {
       throw this.panic(
         "invalid-type",

--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -246,6 +246,23 @@ export class ForeignInterface {
     return Values.unbox(x);
   }
 
+  unbox_typed<T extends Function>(type: T, x: CrochetValue): T["prototype"] {
+    if (x instanceof type) {
+      return x;
+    } else {
+      throw this.panic(
+        "invalid-type",
+        `Invalid type to unbox (${type.name ?? "(native type)"})`,
+        this.record(
+          new Map([
+            ["type", this.box(type)],
+            ["value", x],
+          ])
+        )
+      );
+    }
+  }
+
   // == Operations
   intrinsic_equals(x: CrochetValue, y: CrochetValue) {
     return Values.equals(x, y);

--- a/source/targets/browser/browser.ts
+++ b/source/targets/browser/browser.ts
@@ -32,31 +32,6 @@ export class CrochetForBrowser {
     this.crochet = new Crochet(false, this.fs, this.signal);
   }
 
-  get trusted_core() {
-    // TODO: restrict TCB (needs safer native modules support)
-    return new Set([
-      "crochet.codec.basic",
-      "crochet.concurrency",
-      "crochet.core",
-      "crochet.debug",
-      "crochet.debug.tracing",
-      "crochet.language.csv",
-      "crochet.language.json",
-      "crochet.mathematics",
-      "crochet.novella",
-      "crochet.random",
-      "crochet.text.parsing.lingua",
-      "crochet.text.regex",
-      "crochet.time",
-      "crochet.ui.agata",
-      "crochet.wrapper.node.file-system",
-      "crochet.wrapper.node.http",
-      "crochet.wrapper.node.io",
-      "crochet.wrapper.node.os",
-      "crochet.wrapper.node.shell",
-    ]);
-  }
-
   get system() {
     if (this._booted_system == null) {
       throw new Error(`Crochet not yet booted`);
@@ -158,7 +133,7 @@ export class CrochetForBrowser {
   }
 
   private is_trusted(pkg: Package.Package) {
-    return this.trusted_core.has(pkg.meta.name);
+    return this.crochet.trusted_core.has(pkg.meta.name);
   }
 
   fs: IFileSystem = {

--- a/source/targets/node/node.ts
+++ b/source/targets/node/node.ts
@@ -59,31 +59,6 @@ export class CrochetForNode {
     return Path.join(__dirname, rootRelative, "stdlib");
   }
 
-  get trusted_core() {
-    // TODO: restrict TCB (needs safer native modules support)
-    return new Set([
-      "crochet.codec.basic",
-      "crochet.concurrency",
-      "crochet.core",
-      "crochet.debug",
-      "crochet.debug.tracing",
-      "crochet.language.csv",
-      "crochet.language.json",
-      "crochet.mathematics",
-      "crochet.novella",
-      "crochet.random",
-      "crochet.text.parsing.lingua",
-      "crochet.text.regex",
-      "crochet.time",
-      "crochet.ui.agata",
-      "crochet.wrapper.node.file-system",
-      "crochet.wrapper.node.http",
-      "crochet.wrapper.node.io",
-      "crochet.wrapper.node.os",
-      "crochet.wrapper.node.shell",
-    ]);
-  }
-
   get system() {
     if (this._booted_system == null) {
       throw new Error(`Crochet not yet booted`);
@@ -383,7 +358,7 @@ export class CrochetForNode {
   private async register_standard_library() {
     const pkgs = await this.register_directory(this.stdlib_path);
     for (const pkg of pkgs) {
-      if (this.trusted_core.has(pkg.meta.name)) {
+      if (this.crochet.trusted_core.has(pkg.meta.name)) {
         this.crochet.trust(pkg);
       }
     }

--- a/source/vm/primitives/location.ts
+++ b/source/vm/primitives/location.ts
@@ -188,7 +188,12 @@ export function simple_value(x: CrochetValue): string {
       return `${type_name(x.type)}`;
     }
     case Tag.UNKNOWN: {
-      return `<unknown>`;
+      assert_tag(Tag.UNKNOWN, x);
+      const repr =
+        x.payload instanceof CrochetValue
+          ? simple_value(x.payload)
+          : `native ${inspect(x.payload, false, 3)}`;
+      return `<unknown>(${repr})`;
     }
     case Tag.CELL: {
       assert_tag(Tag.CELL, x);

--- a/stdlib/crochet.concurrency/native/promise.ts
+++ b/stdlib/crochet.concurrency/native/promise.ts
@@ -100,4 +100,12 @@ export default (ffi: ForeignInterface) => {
     const result = yield ffi.await(get_deferred(x).promise);
     return result;
   });
+
+  ffi.defun("promise.spawn", (fn) => {
+    ffi.run_asynchronously(function* () {
+      yield ffi.apply(fn, []);
+      return ffi.nothing;
+    });
+    return ffi.nothing;
+  });
 };

--- a/stdlib/crochet.concurrency/source/promise.crochet
+++ b/stdlib/crochet.concurrency/source/promise.crochet
@@ -11,6 +11,12 @@ command #deferred make =
 command #deferred make: State =
   new deferred(foreign promise.defer(State));
 
+command #deferred promise: (Block is (deferred -> nothing)) -> promise<A> do
+  let Deferred = #deferred make;
+  foreign promise.spawn({ Block(Deferred) } capture);
+  Deferred promise;
+end
+
 command deferred is-resolved =
   foreign promise.is-resolved(self.box);
 

--- a/stdlib/crochet.core/source/result/result.crochet
+++ b/stdlib/crochet.core/source/result/result.crochet
@@ -113,10 +113,13 @@ end
 /// Retrieves the value of a successful [type:result]. If the [type:result]
 /// is a failure, stops the program in a panic, with the given
 /// panic message as the reason.
-command ok value-or-panic: Reason =
+command ok value-or-panic: Reason data: Data =
   self value;
-command error value-or-panic: Reason =
-  panic message: Reason data: self;
+command error value-or-panic: Reason data: Data =
+  panic message: Reason data: [reason -> self, user-data -> Data];
+
+command ok value-or-panic: Reason = self value-or-panic: Reason data: nothing;
+command error value-or-panic: Reason = self value-or-panic: Reason data: nothing;
 
 test "result value-or-panic: Reason" do
   assert (#result ok: 1 | value-or-panic: "Okay!") === 1;

--- a/stdlib/crochet.network.types/crochet.json
+++ b/stdlib/crochet.network.types/crochet.json
@@ -6,6 +6,7 @@
     "source/internal.crochet",
     "source/url/url-path-grammar.lingua",
     "source/url/url-path.crochet",
+    "source/url/url-query.crochet",
     "source/url/url.crochet"
   ],
   "dependencies": ["crochet.core", "crochet.text.parsing.lingua"],

--- a/stdlib/crochet.network.types/crochet.json
+++ b/stdlib/crochet.network.types/crochet.json
@@ -1,0 +1,16 @@
+{
+  "name": "crochet.network.types",
+  "target": "*",
+  "native_sources": ["native/url.js"],
+  "sources": [
+    "source/internal.crochet",
+    "source/url/url-path-grammar.lingua",
+    "source/url/url-path.crochet",
+    "source/url/url.crochet"
+  ],
+  "dependencies": ["crochet.core", "crochet.text.parsing.lingua"],
+  "capabilities": {
+    "requires": [],
+    "provides": []
+  }
+}

--- a/stdlib/crochet.network.types/native/url.ts
+++ b/stdlib/crochet.network.types/native/url.ts
@@ -1,0 +1,35 @@
+import type { ForeignInterface } from "../../../build/crochet";
+
+export default (ffi: ForeignInterface) => {
+  ffi.defun("url.decode-component", (x) => {
+    return ffi.text(decodeURIComponent(ffi.text_to_string(x)));
+  });
+
+  ffi.defun("url.encode-component", (x) => {
+    return ffi.text(encodeURIComponent(ffi.text_to_string(x)));
+  });
+
+  ffi.defun("url.parse", (url) => {
+    return ffi.box(new URL(ffi.text_to_string(url)));
+  });
+
+  ffi.defun("url.hash", (url0) => {
+    const url = ffi.unbox_typed(URL, url0);
+    return ffi.text(url.hash);
+  });
+
+  ffi.defun("url.host", (url0) => {
+    const url = ffi.unbox_typed(URL, url0);
+    return ffi.text(url.host);
+  });
+
+  ffi.defun("url.hostname", (url0) => {
+    const url = ffi.unbox_typed(URL, url0);
+    return ffi.text(url.hostname);
+  });
+
+  ffi.defun("url.origin", (url0) => {
+    const url = ffi.unbox_typed(URL, url0);
+    return ffi.text(url.origin);
+  });
+};

--- a/stdlib/crochet.network.types/native/url.ts
+++ b/stdlib/crochet.network.types/native/url.ts
@@ -70,7 +70,7 @@ export default (ffi: ForeignInterface) => {
 
   ffi.defun("url.set-path", (url0, path) => {
     const url1 = ffi.unbox_typed(URL, url0);
-    const url = new URL(url1);
+    const url = new URL(url1.href);
     url.pathname = ffi.text_to_string(path);
     return ffi.box(url);
   });
@@ -78,14 +78,14 @@ export default (ffi: ForeignInterface) => {
   ffi.defun("url.set-query", (url0, query0) => {
     const url1 = ffi.unbox_typed(URL, url0);
     const query = ffi.unbox_typed(URLSearchParams, query0);
-    const url = new URL(url1);
+    const url = new URL(url1.href);
     url.search = query.toString();
     return ffi.box(url);
   });
 
   ffi.defun("url.set-hash", (url0, hash) => {
     const url1 = ffi.unbox_typed(URL, url0);
-    const url = new URL(url1);
+    const url = new URL(url1.href);
     url.hash = ffi.text_to_string(hash);
     return ffi.box(url);
   });

--- a/stdlib/crochet.network.types/native/url.ts
+++ b/stdlib/crochet.network.types/native/url.ts
@@ -1,4 +1,4 @@
-import type { ForeignInterface } from "../../../build/crochet";
+import type { ForeignInterface, CrochetValue } from "../../../build/crochet";
 
 export default (ffi: ForeignInterface) => {
   ffi.defun("url.decode-component", (x) => {
@@ -31,5 +31,150 @@ export default (ffi: ForeignInterface) => {
   ffi.defun("url.origin", (url0) => {
     const url = ffi.unbox_typed(URL, url0);
     return ffi.text(url.origin);
+  });
+
+  ffi.defun("url.port", (url0) => {
+    const url = ffi.unbox_typed(URL, url0);
+    if (url.port === "") {
+      return ffi.nothing;
+    } else {
+      return ffi.integer(BigInt(url.port));
+    }
+  }))
+
+  ffi.defun("url.query", (url0) => {
+    const url = ffi.unbox_typed(URL, url0);
+    return ffi.box(url.searchParams);
+  });
+
+  ffi.defun("url.pathname", (url0) => {
+    return ffi.text(ffi.unbox_typed(URL, url0).pathname);
+  });
+
+  ffi.defun("url.username", (x) => {
+    return ffi.text(ffi.unbox_typed(URL, x).username);
+  });
+
+  ffi.defun("url.password", (x) => {
+    return ffi.text(ffi.unbox_typed(URL, x).password);
+  });
+
+  ffi.defun("url.protocol", (url0) => {
+    return ffi.text(ffi.unbox_typed(URL, url0).protocol);
+  });
+
+  ffi.defun("url.to-text", (url0) => {
+    const url = ffi.unbox_typed(URL, url0);
+    return ffi.text(url.toString());
+  });
+
+  ffi.defun("url.set-path", (url0, path) => {
+    const url1 = ffi.unbox_typed(URL, url0);
+    const url = new URL(url1);
+    url.pathname = ffi.text_to_string(path);
+    return ffi.box(url);
+  });
+
+  ffi.defun("url.set-query", (url0, query0) => {
+    const url1 = ffi.unbox_typed(URL, url0);
+    const query = ffi.unbox_typed(URLSearchParams, query0);
+    const url = new URL(url1);
+    url.search = query.toString();
+    return ffi.box(url);
+  });
+
+  ffi.defun("url.set-hash", (url0, hash) => {
+    const url1 = ffi.unbox_typed(URL, url0);
+    const url = new URL(url1);
+    url.hash = ffi.text_to_string(hash);
+    return ffi.box(url);
+  });
+
+  // -- search params
+  ffi.defun("url.query-empty", () => {
+    return ffi.box(new URLSearchParams());
+  });
+
+  ffi.defun("url.query-keys", (x0) => {
+    const keys: CrochetValue[] = [];
+    const x = ffi.unbox_typed(URLSearchParams, x0);
+    for (const key of x.keys()) {
+      keys.push(ffi.text(key));
+    }
+    return ffi.list(keys);
+  });
+
+  ffi.defun("url.query-values", (x0) => {
+    const values: CrochetValue[] = [];
+    const x = ffi.unbox_typed(URLSearchParams, x0);
+    for (const value of x.values()) {
+      values.push(ffi.text(value));
+    }
+    return ffi.list(values);
+  });
+
+  ffi.defun("url.query-entries", (x0) => {
+    const entries: CrochetValue[] = [];
+    const x = ffi.unbox_typed(URLSearchParams, x0);
+    for (const [k, v] of x.entries()) {
+      entries.push(ffi.list([ffi.text(k), ffi.text(v)]));
+    }
+    return ffi.list(entries);
+  });
+
+  ffi.defun("url.query-count", (x0) => {
+    const keys = [...ffi.unbox_typed(URLSearchParams, x0).keys()];
+    return ffi.integer(BigInt(keys.length));
+  });
+
+  ffi.defun("url.query-at", (x0, key) => {
+    const x = ffi.unbox_typed(URLSearchParams, x0);
+    return ffi.text(x.get(ffi.text_to_string(key))!);
+  });
+
+  ffi.defun("url.query-contains", (x0, key) => {
+    const x = ffi.unbox_typed(URLSearchParams, x0);
+    return ffi.boolean(x.has(ffi.text_to_string(key)));
+  });
+
+  ffi.defun("url.query-put", (x0, key, value) => {
+    const x1 = ffi.unbox_typed(URLSearchParams, x0);
+    const x = new URLSearchParams(x1);
+    x.set(ffi.text_to_string(key), ffi.text_to_string(value));
+    return ffi.box(x);
+  });
+
+  ffi.defun("url.query-remove", (x0, key) => {
+    const x1 = ffi.unbox_typed(URLSearchParams, x0);
+    const x = new URLSearchParams(x1);
+    x.delete(ffi.text_to_string(key));
+    return ffi.box(x);
+  });
+
+  ffi.defun("url.query-text", (x0) => {
+    const x1 = ffi.unbox_typed(URLSearchParams, x0);
+    const x = new URLSearchParams(x1);
+    x.sort();
+    return ffi.text(x.toString());
+  });
+
+  ffi.defun("url.query-all-at", (x0, key) => {
+    const x1 = ffi.unbox_typed(URLSearchParams, x0);
+    const values = x1.getAll(ffi.text_to_string(key));
+    return ffi.list(values.map((x) => ffi.text(x)));
+  });
+
+  ffi.defun("url.query-append", (x0, key, value) => {
+    const x1 = ffi.unbox_typed(URLSearchParams, x0);
+    const x = new URLSearchParams(x1);
+    x.append(ffi.text_to_string(key), ffi.text_to_string(value));
+    return ffi.box(x);
+  });
+
+  ffi.defun("url.query-sort", (x0) => {
+    const x1 = ffi.unbox_typed(URLSearchParams, x0);
+    const x = new URLSearchParams(x1);
+    x.sort();
+    return ffi.box(x);
   });
 };

--- a/stdlib/crochet.network.types/native/url.ts
+++ b/stdlib/crochet.network.types/native/url.ts
@@ -40,7 +40,7 @@ export default (ffi: ForeignInterface) => {
     } else {
       return ffi.integer(BigInt(url.port));
     }
-  }))
+  });
 
   ffi.defun("url.query", (url0) => {
     const url = ffi.unbox_typed(URL, url0);

--- a/stdlib/crochet.network.types/source/internal.crochet
+++ b/stdlib/crochet.network.types/source/internal.crochet
@@ -1,0 +1,7 @@
+% crochet
+
+singleton internal;
+capability internal;
+
+protect type internal with internal;
+protect global internal with internal;

--- a/stdlib/crochet.network.types/source/url/url-path-grammar.lingua
+++ b/stdlib/crochet.network.types/source/url/url-path-grammar.lingua
@@ -1,0 +1,30 @@
+type url_path_ast =
+  | path(segment: text, previous: url_path_ast)
+  | back(previous: url_path_ast)
+  | id(previous: url_path_ast)
+  | slash(previous: url_path_ast)
+  | root()
+  | relative()
+
+grammar url_path_grammar : url_path_ast {
+  url_path =
+    | p:path end -> p
+
+  path =
+    | p:path "/" ".."       -> url_path_ast.back(p)
+    | p:path "/" "."        -> url_path_ast.id(p)
+    | p:path "/" s:segment  -> url_path_ast.path(s, p)
+    | p:path "/"            -> url_path_ast.slash(p)
+    | ".."                  -> url_path_ast.back(url_path_ast.relative())
+    | "."                   -> url_path_ast.relative()
+    |                       -> url_path_ast.root()
+
+  segment =
+    | s:plain_segment  -> s
+
+  token plain_segment = (unreserved | sub_delims | pct_encoded)+
+  token unreserved = letter | digit | "-" | "." | "_" | "~"
+  token sub_delims = "!" | "$" | "&" | "'" | "(" | ")" | "*" | "+" | "," | ";" | "="
+  token pct_encoded = "%" hex_digit hex_digit
+  token hex_digit = "a".."f" | "A".."F" | "0".."9"
+}

--- a/stdlib/crochet.network.types/source/url/url-path.crochet
+++ b/stdlib/crochet.network.types/source/url/url-path.crochet
@@ -1,0 +1,166 @@
+% crochet
+
+abstract url-path;
+type url-path-id(global previous is url-path) is url-path;
+type url-path-back(global previous is url-path) is url-path;
+type url-path-node(global segment is text, global previous is url-path) is url-path;
+type url-path-slash(global previous is url-path) is url-path;
+singleton url-path-root is url-path;
+singleton url-path-relative is url-path;
+
+command #url-path try-from-text: (Path is text) do
+  url-path-grammar parse: Path
+    | map: (_ reify);
+end
+
+command #url-path from-text: (Path is text) do
+  #url-path try-from-text: Path | value-or-panic: "invalid path" data: [path -> Path];
+end
+
+
+command url-path-ast--path reify =
+  new url-path-node(foreign url.decode-component(self.segment), self.previous reify);
+
+command url-path-ast--slash reify =
+  new url-path-slash(self.previous reify);
+
+command url-path-ast--back reify =
+  new url-path-back(self.previous reify);
+
+command url-path-ast--id reify =
+  new url-path-id(self.previous reify);
+
+command url-path-ast--root reify =
+  url-path-root;
+
+command url-path-ast--relative reify =
+  url-path-relative;
+
+
+command url-path-id normalise =
+  self.previous normalise;
+
+command url-path-back normalise
+requires
+  non-root-previous :: not (self.previous is url-path-root)
+do
+  let Previous = self.previous normalise;
+  assert not (Previous is url-path-root);
+  condition
+    when Previous is url-path-relative => self;
+    when Previous is url-path-back => new url-path-back(Previous);
+    otherwise => Previous previous;
+  end
+end
+
+command url-path-node normalise =
+  new url-path-node(self.segment, self.previous normalise);
+
+command url-path-slash normalise =
+  new url-path-slash(self.previous normalise);
+
+command url-path-root normalise = self;
+command url-path-relative normalise = self;
+
+
+command url-path to-text =
+  self
+    | normalise
+    | to-text: internal
+    | flatten-into-plain-text;
+
+command url-path-node to-text: internal do
+  let Segment = foreign url.encode-component(self.segment);
+  "[self.previous to-text: internal]/[Segment]";
+end
+
+command url-path-slash to-text: internal do
+  "[self.previous to-text: internal]/";
+end
+
+command url-path-back to-text: internal =
+  "[self.previous to-text: internal]/..";
+
+command url-path-id to-text: internal =
+  "[self.previous to-text: internal]/.";
+
+command url-path-root to-text: internal =
+  "";
+  
+
+implement equality for url-path;
+command url-path === (That is url-path) =
+  internal eq: self normalise and: That normalise;
+
+command internal eq: url-path and: url-path = false;
+
+command internal eq: (This is url-path-node) and: (That is url-path-node) =
+  (internal eq: This.segment and: That.segment)
+    and (internal eq: This.previous and: That.previous);
+
+command internal eq: (This is url-path-slash) and: (That is url-path-slash) =
+  (internal eq: This.previous and: That.previous);
+
+command internal eq: (This is url-path-id) and: (That is url-path-id) =
+  internal eq: This.previous and: That.previous;
+
+command internal eq: (This is url-path-back) and: (That is url-path-back) =
+  internal eq: This.previous and: That.previous;
+
+command internal eq: url-path-root and: url-path-root =
+  true;
+
+command internal eq: url-path-relative and: url-path-relative =
+  true;
+
+
+command url-path-id is-absolute = self.previous is-absolute;
+command url-path-back is-absolute = self.previous is-absolute;
+command url-path-node is-absolute = self.previous is-absolute;
+command url-path-slash is-absolute = self.previous is-absolute;
+command url-path-root is-absolute = true;
+command url-path-relative is-absolute = false;
+
+command url-path-id is-relative = self.previous is-relative;
+command url-path-back is-relative = self.previous is-relative;
+command url-path-node is-relative = self.previous is-relative;
+command url-path-slash is-relative = self.previous is-relative;
+command url-path-root is-relative = false;
+command url-path-relative is-relative = true;
+
+
+command url-path / (Segment is static-text) =
+  condition
+    when Segment =:= ".." do
+      assert not (self is url-path-root);
+      new url-path-back(self);
+    end
+
+    when Segment =:= "." =>
+      self;
+
+    otherwise =>
+      new url-path-node(foreign url.decode-component(Segment), self);
+  end;
+
+command url-path / (Path is url-path)
+requires
+  relative :: Path is-relative
+do
+  internal cat: self and: Path;
+end
+
+command internal cat: (A is url-path) and: (B is url-path-relative) =
+  new url-path-id(A);
+
+command internal cat: (A is url-path) and: (B is url-path-id) =
+  new url-path-id(internal cat: A and: B.previous);
+
+command internal cat: (A is url-path) and: (B is url-path-back) =
+  new url-path-back(internal cat: A and: B.previous);
+
+command internal cat: (A is url-path) and: (B is url-path-node) =
+  new url-path-node(B.segment, internal cat: A and: B.previous);
+
+command internal cat: (A is url-path) and: (B is url-path-slash) =
+  new url-path-slash(internal cat: A and: B.previous);

--- a/stdlib/crochet.network.types/source/url/url-path.crochet
+++ b/stdlib/crochet.network.types/source/url/url-path.crochet
@@ -95,7 +95,7 @@ command url-path === (That is url-path) =
 command internal eq: url-path and: url-path = false;
 
 command internal eq: (This is url-path-node) and: (That is url-path-node) =
-  (internal eq: This.segment and: That.segment)
+  (This.segment =:= That.segment)
     and (internal eq: This.previous and: That.previous);
 
 command internal eq: (This is url-path-slash) and: (That is url-path-slash) =
@@ -128,6 +128,9 @@ command url-path-slash is-relative = self.previous is-relative;
 command url-path-root is-relative = false;
 command url-path-relative is-relative = true;
 
+
+command url-path-slash / Segment =
+  self previous / Segment;
 
 command url-path / (Segment is static-text) =
   condition

--- a/stdlib/crochet.network.types/source/url/url-query.crochet
+++ b/stdlib/crochet.network.types/source/url/url-query.crochet
@@ -1,0 +1,77 @@
+% crochet
+
+abstract url-query;
+type url-query-native(box is unknown); // URLSearchParams
+
+
+command #url-query empty =
+  new url-query-native(foreign url.query-empty());
+
+command url-query-native keys =
+  foreign url.query-keys(self.box);
+
+command url-query-native values =
+  foreign url.query-values(self.box);
+
+command url-query-native entries do
+  let Entries = foreign url.query-entries(self.box);
+  Entries map: { X in #association key: X first value: X second };
+end
+
+
+command url-query-native to-text =
+  foreign url.query-text(self.box);
+
+
+implement countable-container for url-query;
+command url-query-native count =
+  foreign url-query-count(self.box);
+
+
+implement mapped-container for url-query;
+command url-query-native at: (Key is text)
+requires
+  contains :: self contains-key: Key
+do
+  foreign url.query-at(self.box, Key);
+end
+
+command url-query-native contains-key: (Keys is text) =
+  foreign url.query-contains(self.box, Key);
+
+command url-query-native all-at: (Key is text)
+requires
+  contains :: self contains-key: Key
+do
+  foreign url.query-all-at(self.box, Key);
+end
+
+
+implement modifiable-mapped-container for url-query;
+command url-query-native at: (Key is text) put: (Value is text) =
+  new url-query-native(foreign url.query-put(self.box, Key, Value));
+
+command url-query-native remove-at: (Key is text) =
+  new url-query-native(foreign url.query-remove(self.box, Key));
+
+command url-query-native at: (Key is text) append: (Value is text) =
+  new url-query-native(foreign url.query-append(self.box, Key, Value));
+
+
+implement foldable-collection for url-query-native;
+command url-query-native fold-from: Initial with: (Combine is ((association<text, text>, B) -> B)) -> B do
+  self entries fold-from: Initial with: Combine;
+end
+
+command url-query-native fold-right-from: Initial with: (Combine is ((association<text, text>, B) -> B)) -> B do
+  self entries fold-right-from: Initial with: Combine;
+end
+
+
+command url-query-native sort =
+  new url-query-native(foreign url.query-sort(self.box));
+
+
+implement equality for url-query;
+command url-query-native === (That is url-query-native) =
+  self to-text =:= That to-text;

--- a/stdlib/crochet.network.types/source/url/url.crochet
+++ b/stdlib/crochet.network.types/source/url/url.crochet
@@ -4,12 +4,20 @@
 
 abstract url;
 
-type url-native(box is unknown); // native URL
+type url-native(box is unknown) is url; // native URL
 
 abstract url-error;
 type url-error-no-username(url is url);
 type url-error-no-password(url is url);
 type url-error-no-port(url is url);
+
+
+implement equality for url-error;
+command url-error === url-error = false;
+
+command url-error-no-username === (That is url-error-no-username) = self.url === That.url;
+command url-error-no-password === (That is url-error-no-password) = self.url === That.url;
+command url-error-no-port === (That is url-error-no-port) = self.url === That.url;
 
 
 // -- Constructors
@@ -28,22 +36,24 @@ end
 command url-native username -> result<text> do
   let Result = foreign url.username(self.box);
   condition
-    when Result is nothing => #result error: new url-error-no-username(self);
+    when Result =:= "" => #result error: new url-error-no-username(self);
     otherwise => #result ok: Result;
   end
 test
-  assert (#url from-text: "http://example.com/") username === (#result error: not-found);
+  assert (#url from-text: "http://example.com/") username
+          === (#result error: new url-error-no-username(#url from-text: "http://example.com/"));
   assert (#url from-text: "http://user:pwd@example.com/") username === (#result ok: "user");
 end
 
 command url-native password -> result<text> do
   let Result = foreign url.password(self.box);
   condition
-    when Result is nothing => #result error: new url-error-no-password(self);
+    when Result =:= "" => #result error: new url-error-no-password(self);
     otherwise => #result ok: Result;
   end
 test
-  assert (#url from-text: "http://example.com/") password === (#result error: not-found);
+  assert (#url from-text: "http://example.com/") password
+          === (#result error: new url-error-no-password(#url from-text: "http://example.com/"));
   assert (#url from-text: "http://user:pwd@example.com/") password === (#result ok: "pwd");
 end
 
@@ -55,17 +65,21 @@ test
 end
 
 command url-native port -> result<integer> do
-  let Result = url.port(self.box);
+  let Result = foreign url.port(self.box);
   condition
     when Result is nothing => #result error: new url-error-no-port(self);
     otherwise => #result ok: Result;
   end
+test
+  assert (#url from-text: "http://example.com/") port
+          === (#result error: new url-error-no-port(#url from-text: "http://example.com"));
+  assert (#url from-text: "http://example.com:8000/") port === (#result ok: 8000);
 end
 
 command url-native path -> url-path =
   #url-path from-text: (foreign url.pathname(self.box))
 test
-  assert (#url from-text: "http://example.com") path === (#url-path from-text: "/")
+  assert (#url from-text: "http://example.com") path === (#url-path from-text: "/");
   assert (#url from-text: "http://example.com/") path === (#url-path from-text: "/");
   assert (#url from-text: "http://example.com/a/b/c") path === (#url-path from-text: "/a/b/c");
 end
@@ -79,5 +93,44 @@ test
 end
 
 
+command url-native query =
+  new url-query-native(foreign url.query(self.box))
+test
+  assert (#url from-text: "http://example.com/") query === (#url-query empty);
+  assert (#url from-text: "http://example.com/?") query === (#url-query empty);
+  assert (#url from-text: "http://example.com/?a=1&b=2") query === (#url-query empty | at: "a" put: "1" | at: "b" put: "2");
+  assert (#url from-text: "http://example.com/?a=1&a=2") query === (#url-query empty | at: "a" append: "1" | at: "a" append: "2");
+end
 
 
+// -- Modifying
+command url-native / Segment do
+  let Path = self path / Segment;
+  new url-native(foreign url.set-path(self.box, Path to-text));
+test
+  assert ((#url from-text: "http://example.com/a/b") / "c") === (#url from-text: "http://example.com/a/b/c");
+  assert ((#url from-text: "http://example.com/a/b") / "..") === (#url from-text: "http://example.com/a");
+  assert ((#url from-text: "http://example.com/") / "a" / "b" | to-text) =:= "http://example.com/a/b";
+end
+
+command url-native with-query: (F is (url-query -> url-query)) do
+  let Query = F(self query);
+  let Url =
+    condition
+      when Query is url-query-native => foreign url.set-query(self.box, Query.box);
+    end;
+  new url-native(Url);
+end
+
+command url-native with-hash: (Hash is text) =
+  new url-native(foreign url.set-hash(self.box, Hash));
+
+
+// -- Serialisation
+command url-native to-text =
+  foreign url.to-text(self.box);
+
+
+implement equality for url;
+command url-native === (That is url-native) =
+  self to-text =:= That to-text;

--- a/stdlib/crochet.network.types/source/url/url.crochet
+++ b/stdlib/crochet.network.types/source/url/url.crochet
@@ -1,0 +1,83 @@
+% crochet
+
+// See https://url.spec.whatwg.org/
+
+abstract url;
+
+type url-native(box is unknown); // native URL
+
+abstract url-error;
+type url-error-no-username(url is url);
+type url-error-no-password(url is url);
+type url-error-no-port(url is url);
+
+
+// -- Constructors
+command #url from-text: (Url is static-text) =
+  new url-native(foreign url.parse(Url));
+
+
+// -- Components
+command url-native protocol -> text =
+  foreign url.protocol(self.box)
+test
+  assert (#url from-text: "http://example.com") protocol =:= "http:";
+  assert (#url from-text: "https://example.com") protocol =:= "https:";
+end
+
+command url-native username -> result<text> do
+  let Result = foreign url.username(self.box);
+  condition
+    when Result is nothing => #result error: new url-error-no-username(self);
+    otherwise => #result ok: Result;
+  end
+test
+  assert (#url from-text: "http://example.com/") username === (#result error: not-found);
+  assert (#url from-text: "http://user:pwd@example.com/") username === (#result ok: "user");
+end
+
+command url-native password -> result<text> do
+  let Result = foreign url.password(self.box);
+  condition
+    when Result is nothing => #result error: new url-error-no-password(self);
+    otherwise => #result ok: Result;
+  end
+test
+  assert (#url from-text: "http://example.com/") password === (#result error: not-found);
+  assert (#url from-text: "http://user:pwd@example.com/") password === (#result ok: "pwd");
+end
+
+command url-native hostname -> text =
+  foreign url.hostname(self.box)
+test
+  assert (#url from-text: "http://example.com/") hostname =:= "example.com";
+  assert (#url from-text: "http://example.com:80") hostname =:= "example.com";
+end
+
+command url-native port -> result<integer> do
+  let Result = url.port(self.box);
+  condition
+    when Result is nothing => #result error: new url-error-no-port(self);
+    otherwise => #result ok: Result;
+  end
+end
+
+command url-native path -> url-path =
+  #url-path from-text: (foreign url.pathname(self.box))
+test
+  assert (#url from-text: "http://example.com") path === (#url-path from-text: "/")
+  assert (#url from-text: "http://example.com/") path === (#url-path from-text: "/");
+  assert (#url from-text: "http://example.com/a/b/c") path === (#url-path from-text: "/a/b/c");
+end
+
+
+command url-native hash =
+  foreign url.hash(self.box)
+test
+  assert (#url from-text: "http://example.com/#abc") hash =:= "#abc";
+  assert (#url from-text: "http://example.com/") hash =:= "";
+end
+
+
+
+


### PR DESCRIPTION
Part of the upcoming library of safe network-related types.

The URL type does not yet follow the living URL spec, however. There are a handful things that it doesn't support wrt origin and opaqueness. But right now this is more aimed at using it with http requests.