### PR TITLE
Basic HTTP client

### DIFF
--- a/examples/agata/todo-list/crochet.json
+++ b/examples/agata/todo-list/crochet.json
@@ -20,7 +20,7 @@
     "crochet.debug"
   ],
   "capabilities": {
-    "requires": [],
+    "requires": ["crochet.ui.agata/ui-control"],
     "provides": []
   }
 }

--- a/examples/agata/widget-gallery/crochet.json
+++ b/examples/agata/widget-gallery/crochet.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": ["crochet.core", "crochet.concurrency", "crochet.ui.agata"],
   "capabilities": {
-    "requires": [],
+    "requires": ["crochet.ui.agata/ui-control", "crochet.ui.agata/network"],
     "provides": []
   }
 }

--- a/examples/agata/widget-gallery/source/layout/card.crochet
+++ b/examples/agata/widget-gallery/source/layout/card.crochet
@@ -66,7 +66,6 @@ command layout-card page do
           "The kitchen-sink package for Crochet."
         ]
       ]
-      | style: "narrow"
     ]
   ]
 end

--- a/source/crochet/crochet.ts
+++ b/source/crochet/crochet.ts
@@ -123,6 +123,7 @@ export class Crochet {
       "crochet.text.regex",
       "crochet.time",
       "crochet.ui.agata",
+      "crochet.wrapper.browser.web-apis",
       "crochet.wrapper.node.file-system",
       "crochet.wrapper.node.http",
       "crochet.wrapper.node.io",

--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -290,6 +290,14 @@ export class ForeignInterface {
     return x.tag === Tag.LIST;
   }
 
+  is_text(x: CrochetValue) {
+    return x.tag === Tag.TEXT;
+  }
+
+  is_nothing(x: CrochetValue) {
+    return x.tag === Tag.NOTHING;
+  }
+
   is_thunk_forced(x: CrochetValue) {
     return Values.is_thunk_forced(x);
   }

--- a/source/node-cli/server.ts
+++ b/source/node-cli/server.ts
@@ -65,6 +65,10 @@ export default async (root: string, port: number, www: string) => {
   }
 
   app.listen(port, () => {
-    console.log(`Server started at http://localhost:${port}/`);
+    const caps = [...pkg.meta.capabilities.requires.values()].join(",");
+    const url = new URL("http://localhost");
+    url.port = String(port);
+    url.searchParams.set("capabilities", caps);
+    console.log(`Server started at ${url.toString()}`);
   });
 };

--- a/source/targets/node/node.ts
+++ b/source/targets/node/node.ts
@@ -283,7 +283,7 @@ export class CrochetForNode {
     async report_test(message) {},
   };
 
-  private async request_new_capabilities(
+  async request_new_capabilities(
     config: StorageConfig,
     requirements: Map<Package.Capability, Package.ResolvedPackage[]>,
     root: Package.Package
@@ -309,7 +309,7 @@ export class CrochetForNode {
     }
   }
 
-  private async request_updated_capabilities(
+  async request_updated_capabilities(
     previous: Package.Capability[],
     missing_set: Set<Package.Capability>,
     config: StorageConfig,

--- a/stdlib/crochet.core/crochet.json
+++ b/stdlib/crochet.core/crochet.json
@@ -93,6 +93,7 @@
     "source/result/result.crochet",
 
     "source/sealing/conversions.crochet",
+    "source/sealing/secret.crochet",
 
     "source/text/ascii.crochet",
     "source/text/basic.crochet",

--- a/stdlib/crochet.core/source/debug/constructors.crochet
+++ b/stdlib/crochet.core/source/debug/constructors.crochet
@@ -1,5 +1,9 @@
 % crochet
 
+/// Represents a secret value
+command #document secret: Value seal: (Seal is secret-seal) =
+  new doc-secret(Value, Seal);
+
 /// Represents nothing
 command #document empty =
   doc-empty;

--- a/stdlib/crochet.core/source/debug/representations.crochet
+++ b/stdlib/crochet.core/source/debug/representations.crochet
@@ -24,6 +24,17 @@ command debug-representation for: (X is interpolation) perspective: default-pers
   #document flow: (X parts map: (self for: _ perspective: default-perspective))
     | typed: #interpolation;
 
+command debug-representation for: (X is secret) perspective: (P is default-perspective) do
+  let Value = self for: X.value perspective: P;
+  let Seal = self for: X.seal perspective: P;
+  #document secret: Value seal: Seal
+    | typed: #secret;
+end
+
+command debug-representation for: (X is secret-seal) perspective: (P is default-perspective) =
+  #document text: X.description
+    | typed: #secret-seal;
+
 command debug-representation for: (X is record) perspective: default-perspective do
   let Rows = (#map from: X) pairs
               | map: { P in #document table-row: [

--- a/stdlib/crochet.core/source/debug/serialisation.crochet
+++ b/stdlib/crochet.core/source/debug/serialisation.crochet
@@ -196,6 +196,13 @@ command debug-serialisation for: (X is doc-timeline) =
     frames -> X.frames map: (self for: _)
   ];
 
+command debug-serialisation for: (X is doc-secret) =
+  [
+    tag -> "secret",
+    value -> self for: X.value,
+    seal -> self for: X.seal,
+  ];
+
 // -- Units
 command debug-serialisation for: (X is doc-point2d) =
   [

--- a/stdlib/crochet.core/source/debug/types.crochet
+++ b/stdlib/crochet.core/source/debug/types.crochet
@@ -295,3 +295,6 @@ type doc-box(
 
 /// A document that provides a timeline
 type doc-timeline(frames is list<document>) is document;
+
+/// A document that provides a secret value
+type doc-secret(value is document, seal is document) is document;

--- a/stdlib/crochet.core/source/sealing/secret.crochet
+++ b/stdlib/crochet.core/source/sealing/secret.crochet
@@ -1,0 +1,19 @@
+% crochet
+
+type secret-seal(description is text);
+type secret(value, seal is secret-seal);
+
+command #secret-seal description: (Description is text) =
+  new secret-seal(Description);
+
+command #secret value: Value seal: (Seal is secret-seal) =
+  new secret(Value, Seal);
+
+command secret unseal: (Seal is secret-seal)
+requires
+  same-seal :: self.seal =:= Seal
+do
+  self.value;
+end
+
+

--- a/stdlib/crochet.ui.agata/crochet.json
+++ b/stdlib/crochet.ui.agata/crochet.json
@@ -9,7 +9,7 @@
     "native/uri.js"
   ],
   "sources": [
-    "source/main.crochet",
+    "source/capabilities.crochet",
 
     "source/core/api.crochet",
     "source/core/reference.crochet",
@@ -91,6 +91,6 @@
   ],
   "capabilities": {
     "requires": [],
-    "provides": []
+    "provides": ["network", "ui-control", "arbitrary-fonts", "arbitrary-css"]
   }
 }

--- a/stdlib/crochet.ui.agata/source/capabilities.crochet
+++ b/stdlib/crochet.ui.agata/source/capabilities.crochet
@@ -1,0 +1,21 @@
+% crochet
+  
+capability internal;
+
+singleton internal;
+protect global internal with internal;
+protect type internal with internal;
+
+
+/// Allows constructing widgets that make network requests (e.g.: URL-based images).
+capability network;
+
+/// Allows control over rendering and setup. This should only be granted to
+/// top-level applications, usually.
+capability ui-control;
+
+/// Allows control over loading arbitrary fonts. Particularly dangerous.
+capability arbitrary-fonts;
+
+/// Allows arbitrary CSS. Particularly dangerous.
+capability arbitrary-css;

--- a/stdlib/crochet.ui.agata/source/core/api.crochet
+++ b/stdlib/crochet.ui.agata/source/core/api.crochet
@@ -12,6 +12,8 @@ end
 
 
 singleton agata;
+protect type agata with ui-control;
+protect global agata with ui-control;
 
 command agata show: (Widget has to-widget) do
   perform agata-presentation.show(Widget as widget | commit);

--- a/stdlib/crochet.ui.agata/source/core/font/types.crochet
+++ b/stdlib/crochet.ui.agata/source/core/font/types.crochet
@@ -1,6 +1,8 @@
 % crochet
 
 singleton agata-font;
+protect type agata-font with arbitrary-fonts;
+protect global agata-font with arbitrary-fonts;
 
 type font(
   family-set is set<text>,

--- a/stdlib/crochet.ui.agata/source/core/image.crochet
+++ b/stdlib/crochet.ui.agata/source/core/image.crochet
@@ -10,12 +10,9 @@ abstract network-error;
 type arbitrary-network-error(image is network-image) is network-error;
 
 command network-image preload do
-  let Deferred = #deferred make;
-  foreign dom.preload-image(self.uri, { Result in
-    condition
-      when Result is true => Deferred resolve: nothing;
-      when Result is text => Deferred reject: new arbitrary-network-error(self);
-    end
-  } capture);
-  Deferred promise;
+  let Ok = foreign dom.preload-image(self.uri);
+  condition
+    when Ok => #result ok: self;
+    otherwise => #result error: new arbitrary-network-error(self);
+  end
 end

--- a/stdlib/crochet.ui.agata/source/core/network.crochet
+++ b/stdlib/crochet.ui.agata/source/core/network.crochet
@@ -1,6 +1,8 @@
 % crochet
 
 singleton agata-network;
+protect type agata-network with network;
+protect global agata-network with network;
 
 command agata-network image: (Uri is static-text) =
   new network-image(Uri);

--- a/stdlib/crochet.ui.agata/source/dom/dom-client.crochet
+++ b/stdlib/crochet.ui.agata/source/dom/dom-client.crochet
@@ -4,6 +4,8 @@ open crochet.time;
 open crochet.concurrency;
 
 singleton agata-dom;
+protect type agata-dom with ui-control;
+protect global agata-dom with ui-control;
 
 type dom-routing(
   router is cell<router>,

--- a/stdlib/crochet.ui.agata/source/dom/dom-widgets.crochet
+++ b/stdlib/crochet.ui.agata/source/dom/dom-widgets.crochet
@@ -1,8 +1,11 @@
 % crochet
 
 abstract dom-widget is widget;
+protect type dom-widget with arbitrary-css;
+
 type dom-widget-themed(content is widget, class-name is text) is dom-widget;
 type dom-widget-css(content is text) is dom-widget;
+
 
 command #dom-widget themed: (Theme is text) content: (Content has to-widget) =
   new dom-widget-themed(Content as widget, Theme);

--- a/stdlib/crochet.ui.agata/source/main.crochet
+++ b/stdlib/crochet.ui.agata/source/main.crochet
@@ -1,7 +1,0 @@
-% crochet
-  
-capability internal;
-
-singleton internal;
-protect global internal with internal;
-protect type internal with internal;

--- a/stdlib/crochet.ui.agata/source/widget/input/button.crochet
+++ b/stdlib/crochet.ui.agata/source/widget/input/button.crochet
@@ -49,7 +49,7 @@ command #widget card-button: (Items is list) =
 command #widget icon-button: (Icon is widget-icon) =
   new widget-icon-button(
     icon -> Icon,
-    button -> #widget button: "" | style: "clear"
+    button -> #widget button: "" | style: button-style-clear
   );
 
 command #widget icon-button: (Name is static-text) =
@@ -60,7 +60,7 @@ command #widget action-button: (Title has to-widget) =
     icon -> nothing,
     title -> Title,
     description -> "",
-    button -> #widget button: "" | style: "clear",
+    button -> #widget button: "" | style: button-style-clear,
   );
 
 

--- a/stdlib/crochet.ui.agata/source/widget/layout/card.crochet
+++ b/stdlib/crochet.ui.agata/source/widget/layout/card.crochet
@@ -25,7 +25,7 @@ command widget-card style: (Style is card-style) =
   new widget-card(self with style -> Style);
 
 command widget-card style: (Style is static-text) =
-  self style: (#card-style from-text: Name);
+  self style: (#card-style from-text: Style);
 
 command #card-style from-text: (Name is static-text) do
   condition

--- a/stdlib/crochet.wrapper.browser.web-apis/crochet.json
+++ b/stdlib/crochet.wrapper.browser.web-apis/crochet.json
@@ -1,0 +1,24 @@
+{
+  "name": "crochet.wrapper.browser.web-apis",
+  "target": "browser",
+  "native_sources": ["native/http.js"],
+  "sources": [
+    "source/internal.crochet",
+    "source/http/body.crochet",
+    "source/http/headers.crochet",
+    "source/http/request.crochet",
+    "source/http/sent-request.crochet",
+    "source/http/response.crochet",
+    "source/http/error.crochet"
+  ],
+  "dependencies": [
+    "crochet.core",
+    "crochet.network.types",
+    "crochet.concurrency",
+    "crochet.language.json"
+  ],
+  "capabilities": {
+    "requires": [],
+    "provides": []
+  }
+}

--- a/stdlib/crochet.wrapper.browser.web-apis/crochet.json
+++ b/stdlib/crochet.wrapper.browser.web-apis/crochet.json
@@ -3,7 +3,7 @@
   "target": "browser",
   "native_sources": ["native/http.js"],
   "sources": [
-    "source/internal.crochet",
+    "source/capabilities.crochet",
     "source/http/body.crochet",
     "source/http/headers.crochet",
     "source/http/request.crochet",
@@ -19,6 +19,6 @@
   ],
   "capabilities": {
     "requires": [],
-    "provides": []
+    "provides": ["http"]
   }
 }

--- a/stdlib/crochet.wrapper.browser.web-apis/native/http.ts
+++ b/stdlib/crochet.wrapper.browser.web-apis/native/http.ts
@@ -1,0 +1,104 @@
+import type { ForeignInterface, CrochetValue } from "../../../build/crochet";
+
+export default (ffi: ForeignInterface) => {
+  function unwrap_body(x: CrochetValue) {
+    if (ffi.is_text(x)) {
+      return ffi.text_to_string(x);
+    } else if (ffi.is_nothing(x)) {
+      return null;
+    } else {
+      throw ffi.panic(
+        "invalid-body",
+        "Unsupported body value",
+        ffi.record(new Map([["body", x]]))
+      );
+    }
+  }
+
+  function unwrap_headers(headers0: CrochetValue) {
+    const headers = ffi.list_to_array(headers0);
+    return headers.map(([k, v]: any) => [
+      ffi.text_to_string(k),
+      ffi.text_to_string(v),
+    ]);
+  }
+
+  function unwrap_integrity(x: CrochetValue) {
+    if (ffi.is_text(x)) {
+      return ffi.text_to_string(x);
+    } else if (ffi.is_nothing(x)) {
+      return undefined;
+    } else {
+      throw ffi.panic("invalid-type", "Expected text or nothing", x);
+    }
+  }
+
+  ffi.defun(
+    "http.fetch",
+    (
+      url,
+      method,
+      body,
+      headers,
+      cache,
+      mode,
+      credentials,
+      redirect,
+      referrer,
+      integrity
+    ) => {
+      const abort = new AbortController();
+      const response = fetch(ffi.text_to_string(url), {
+        method: ffi.text_to_string(method),
+        body: unwrap_body(body),
+        headers: unwrap_headers(headers),
+        cache: ffi.text_to_string(cache) as any,
+        mode: ffi.text_to_string(mode) as any,
+        credentials: ffi.text_to_string(credentials) as any,
+        redirect: ffi.text_to_string(redirect) as any,
+        referrer: ffi.text_to_string(referrer),
+        integrity: unwrap_integrity(integrity),
+        signal: abort.signal,
+      });
+      return ffi.record(
+        new Map([
+          ["abort", ffi.box(abort)],
+          ["response", ffi.box(response)],
+        ])
+      );
+    }
+  );
+
+  ffi.defun("http.abort", (abort) => {
+    ffi.unbox_typed(AbortController, abort).abort();
+    return ffi.nothing;
+  });
+
+  ffi.defmachine("http.wait-response", function* (promise0) {
+    const promise = ffi.unbox_typed(Promise, promise0);
+    let value: CrochetValue;
+    try {
+      value = yield ffi.await(promise.then((x) => ffi.box(x)));
+    } catch (error: any) {
+      return ffi.record(
+        new Map([
+          ["ok", ffi.boolean(false)],
+          ["reason", ffi.text(String(error))],
+        ])
+      );
+    }
+    ffi.unbox_typed(Response, value);
+    return ffi.record(
+      new Map([
+        ["ok", ffi.boolean(true)],
+        ["value", value],
+      ])
+    );
+  });
+
+  ffi.defmachine("http.response-text", function* (response0) {
+    const response = ffi.unbox_typed(Response, response0);
+    const text = yield ffi.await(response.text().then((x) => ffi.text(x)));
+    return text;
+  });
+};

--- a/stdlib/crochet.wrapper.browser.web-apis/source/capabilities.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/capabilities.crochet
@@ -1,0 +1,11 @@
+% crochet
+
+singleton internal;
+capability internal;
+
+protect type internal with internal;
+protect global internal with internal;
+
+
+/// Allows creating and sending http requests
+capability http;

--- a/stdlib/crochet.wrapper.browser.web-apis/source/http/body.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/http/body.crochet
@@ -1,0 +1,49 @@
+% crochet
+
+open crochet.language.json;
+
+abstract http-body;
+
+singleton http-body-none is http-body;
+type http-body-text(value is text) is http-body;
+type http-body-json(value) is http-body;
+
+trait to-http-body with
+  command X as http-body -> http-body;
+end
+
+implement to-http-body for http-body;
+command http-body as http-body = self;
+
+implement to-http-body for text;
+command text as http-body = #http-body text: self;
+
+implement to-http-body for nothing;
+command nothing as http-body = http-body-none;
+
+
+
+command #http-body none =
+  http-body-none;
+
+
+command #http-body text: (Value is text) =
+  new http-body-text(Value);
+
+command #http-body text: (Value is interpolation) =
+  #http-body text: Value flatten-into-plain-text;
+
+
+command #http-body json: Value =
+  new http-body-json(Value);
+
+
+command internal serialise-http-body: (Body is http-body-none) =
+  nothing;
+
+command internal serialise-http-body: (Body is http-body-text) =
+  self.value;
+
+command internal serialise-http-body: (Body is http-body-json) =
+  #json serialise: Body;
+

--- a/stdlib/crochet.wrapper.browser.web-apis/source/http/error.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/http/error.crochet
@@ -1,0 +1,9 @@
+% crochet
+
+abstract http-error;
+
+type http-error-arbitrary(reason is text, request is http-request) is http-error;
+
+
+command internal lift-http-error-reason: Reason request: Request =
+  new http-error-arbitrary(Reason, Request);

--- a/stdlib/crochet.wrapper.browser.web-apis/source/http/headers.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/http/headers.crochet
@@ -1,0 +1,88 @@
+% crochet
+
+abstract http-header-value;
+type http-header-text(value is text) is http-header-value;
+type http-header-secret(value is secret<http-header-value>) is http-header-value;
+
+type http-header(name is text, value is (X has to-http-header-value));
+type http-headers(headers is map<text, http-header>);
+
+trait to-http-header-value with
+  command X as http-header-value -> http-header-value;
+end
+
+implement to-http-header-value for http-header-value;
+command http-header-value as http-header-value = self;
+
+implement to-http-header-value for text;
+command text as http-header-value = new http-header-text(self);
+
+define sensitive-header-seal =
+  lazy (#secret-seal description: "sensitive HTTP header");
+
+define sensitive-headers = [
+  "www-authenticate",
+  "authorization",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "cookie2",
+  "set-cookie2"
+];
+
+command #http-headers empty =
+  new http-headers(#map empty);
+
+command http-headers at: (Key0 is text) put: (Value0 has to-http-header-value)
+requires
+  ascii :: Key0 is-ascii
+do
+  let Key = Key0 ascii to-lower-case to-text;
+  let Value = Value0 as http-header-value;
+  condition
+    when (sensitive-headers contains: Key) and (not (Value is http-header-secret)) =>
+      self at: Key0 put-sensitive: Value;
+
+    otherwise =>
+      new http-headers(self with headers -> self.headers at: Key put: Value);
+  end
+end
+
+command http-headers at: (Key0 is text) put-sensitive: (Value0 has to-http-header-value)
+requires
+  ascii :: Key0 is-ascii
+do
+  let Key = Key0 ascii to-lower-case to-text;
+  let Value =
+    Value0 as http-header-value
+      |> #secret value: _ seal: (force sensitive-header-seal)
+      |> { X in new http-header-secret(X) };
+  new http-headers(self with headers -> self.headers at: Key put: Value);
+end
+
+
+command internal serialise-header-value: (X is http-header-text) =
+  X.value;
+
+command internal serialise-header-value: (X is http-header-secret) =
+  internal serialise-header-value: (X.value unseal: (force sensitive-header-seal));
+
+
+command internal serialise-headers: (X is http-headers) =
+  X.headers entries
+    | map: { Pair in [Pair first, internal serialise-header-value: Pair second] };
+
+
+command internal http-headers: Headers body: (Body is http-body-text) =
+  Headers
+    |> _ at: "content-type" put: "text/plain"
+    |> internal serialise-headers: _;
+
+command internal http-headers: Headers body: (Body is http-body-json) =
+  Headers
+    |> _ at: "content-type" put: "application/json"
+    |> internal serialise-headers: _;
+
+command internal http-headers: Headers body: http-body-none =
+  internal serialise-headers: Headers;

--- a/stdlib/crochet.wrapper.browser.web-apis/source/http/request.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/http/request.crochet
@@ -14,6 +14,8 @@ type http-request(
   integrity is http-integrity
 );
 
+protect type http-request with http;
+
 abstract http-method;
 singleton http-head is http-method;
 singleton http-get is http-method;

--- a/stdlib/crochet.wrapper.browser.web-apis/source/http/request.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/http/request.crochet
@@ -1,0 +1,117 @@
+% crochet
+
+open crochet.network.types;
+
+type http-request(
+  url is url,
+  method is http-method,
+  headers is http-headers,
+  cache is http-cache,
+  mode is http-mode,
+  credentials is http-credentials,
+  redirect is http-redirect,
+  referrer is http-referrer,
+  integrity is http-integrity
+);
+
+abstract http-method;
+singleton http-head is http-method;
+singleton http-get is http-method;
+type http-post(body is http-body) is http-method;
+type http-delete(body is http-body) is http-method;
+type http-put(body is http-body) is http-method;
+type http-patch(body is http-body) is http-method;
+
+enum http-mode =
+  http-mode-cors,
+  http-mode-no-cors,
+  http-mode-same-origin,
+  http-mode-navigate;
+
+enum http-credentials =
+  http-credentials-omit,
+  http-credentials-same-origin,
+  http-credentials-include;
+
+enum http-redirect =
+  http-redirect-follow,
+  http-redirect-error,
+  http-redirect-manual;
+
+enum http-cache =
+  http-cache-default,
+  http-cache-no-store,
+  http-cache-reload,
+  http-cache-no-cache,
+  http-cache-force-cache,
+  http-cache-only-if-cached;
+
+abstract http-referrer;
+singleton http-referrer-no-referrer is http-referrer;
+singleton http-referrer-client is http-referrer;
+type http-referrer-url(url is url) is http-referrer;
+
+
+abstract http-integrity;
+singleton http-integrity-skip is http-integrity;
+type http-integrity-check(hash is text) is http-integrity;
+
+
+command #http-request url: (Url is static-text) =
+  #http-request url: (#url from-text: Url);
+
+command #http-request url: (Url is url) =
+  new http-request(
+    url -> Url,
+    method -> http-get,
+    headers -> #http-headers empty,
+    cache -> http-cache-default,
+    mode -> http-mode-cors,
+    credentials -> http-credentials-same-origin,
+    redirect -> http-redirect-follow,
+    referrer -> http-referrer-client,
+    integrity -> http-integrity-skip,
+  );
+
+command http-request method: (M is http-method) =
+  new http-request(self with method -> M);
+
+command http-request get = self method: http-get;
+command http-request head = self method: http-head;
+command http-request post: (Body has to-http-body) = self method: new http-post(Body as http-body);
+command http-request delete: (Body has to-http-body) = self method: new http-delete(Body as http-body);
+command http-request put: (Body has to-http-body) = self method: new http-put(Body as http-body);
+command http-request patch: (Body has to-http-body) = self method: new http-post(Body as http-body);
+
+command http-request mode: (Mode is http-mode) =
+  new http-request(self with mode -> Mode);
+
+command http-request credentials: (Credentials is http-credentials) =
+  new http-request(self with credentials -> Credentials);
+
+command http-request redirect: (Redirect is http-redirect) =
+  new http-request(self with redirect -> Redirect);
+
+command http-request referrer: (Referrer is http-referrer) =
+  new http-request(self with referrer -> Referrer);
+
+command http-request integrity: (Integrity is http-integrity) =
+  new http-request(self with integrity -> Integrity);
+
+command http-request cache-mode: (Mode is http-cache) =
+  new http-request(self with cache -> Mode);
+
+command http-request headers: (Headers is http-headers) =
+  new http-request(self with headers -> Headers);
+
+command http-request headers: (F is (http-headers -> http-headers)) =
+  new http-request(self with headers -> F(self.headers));
+
+command http-request headers: (Headers0 is record) do
+  let Headers =
+    #map from: Headers0
+      |> _ pairs
+      |> _ fold-from: #http-headers empty with: { H, P in H at: P first put: P second };
+  new http-request(self with headers -> Headers);
+end
+

--- a/stdlib/crochet.wrapper.browser.web-apis/source/http/response.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/http/response.crochet
@@ -1,0 +1,24 @@
+% crochet
+
+type http-response(
+  box is unknown, // Response
+);
+
+type http-response-body(
+  response is http-response,
+);
+
+
+command http-response status =
+  foreign http.status(self.box);
+
+command http-response body =
+  new http-response-body(self);
+
+
+command http-response-body text =
+  foreign http.response-text(self.response.box);
+
+command http-response-body json =
+  #json parse: self text;
+

--- a/stdlib/crochet.wrapper.browser.web-apis/source/http/sent-request.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/http/sent-request.crochet
@@ -1,0 +1,116 @@
+% crochet
+
+enum http-request-state =
+  http-request-state-in-flight,
+  http-request-state-done,
+  http-request-state-failed,
+  http-request-state-aborted;
+
+type sent-http-request(
+  request is http-request,
+  state is cell<http-request-state>,
+  abort is unknown, // AbortController
+  response is unknown, // Promise<Response>
+);
+
+command http-request send do
+  let Method = internal http-method-name: self.method;
+  let Body = internal http-body: self.method;
+  let Headers = internal http-headers: self.headers body: Body;
+  let Cache = internal http-cache: self.cache;
+  let Mode = internal http-mode: self.mode;
+  let Credentials = internal http-credentials: self.credentials;
+  let Redirect = internal http-redirect: self.redirect;
+  let Referrer = internal http-referrer: self.referrer;
+  let Integrity = internal http-integrity: self.integrity;
+
+  let Result = foreign http.fetch(
+    self.url to-text,
+    Method,
+    internal serialise-http-body: Body,
+    Headers,
+    Cache,
+    Mode,
+    Credentials,
+    Redirect,
+    Referrer,
+    Integrity,
+  );
+
+  new sent-http-request(
+    request -> self,
+    state -> #cell with-value: http-request-state-in-flight,
+    abort -> Result.abort,
+    response -> Result.response,
+  );
+end
+
+
+command internal http-method-name: http-head = "HEAD";
+command internal http-method-name: http-get = "GET";
+command internal http-method-name: http-post = "POST";
+command internal http-method-name: http-delete = "DELETE";
+command internal http-method-name: http-put = "PUT";
+command internal http-method-name: http-patch = "PATCH";
+
+
+command internal http-body: http-head = http-body-none;
+command internal http-body: http-get = http-body-none;
+command internal http-body: (Method is http-method) = Method.body;
+
+
+command internal http-cache: http-cache-default = "default";
+command internal http-cache: http-cache-no-store = "no-store";
+command internal http-cache: http-cache-reload = "reload";
+command internal http-cache: http-cache-no-cache = "no-cache";
+command internal http-cache: http-cache-force-cache = "force-cache";
+command internal http-cache: http-cache-only-if-cached = "only-if-cached";
+
+
+command internal http-mode: http-mode-cors = "cors";
+command internal http-mode: http-mode-no-cors = "no-cors";
+command internal http-mode: http-mode-same-origin = "same-origin";
+command internal http-mode: http-mode-navigate = "navigate";
+
+
+command internal http-credentials: http-credentials-omit = "omit";
+command internal http-credentials: http-credentials-same-origin = "same-origin";
+command internal http-credentials: http-credentials-include = "include";
+
+
+command internal http-redirect: http-redirect-follow = "follow";
+command internal http-redirect: http-redirect-error = "error";
+command internal http-redirect: http-redirect-manual = "manual";
+
+
+command internal http-referrer: http-referrer-no-referrer = "";
+command internal http-referrer: http-referrer-client = "about:client";
+command internal http-referrer: http-referrer-url = self.url to-text;
+
+
+command internal http-integrity: http-integrity-skip = nothing;
+command internal http-integrity: http-integrity-check = self.hash;
+
+
+command sent-http-request state =
+  self.state value;
+
+command sent-http-request abort
+requires
+  in-flight :: self.state =:= http-request-state-in-flight
+do
+  foreign http.abort(self.abort);
+  self.state <- http-request-state-aborted;
+  self;
+end
+
+command sent-http-request response do
+  let Response = foreign http.wait-response(self.response);
+  condition
+    when Response.ok =>
+      #result ok: new http-response(Response.value);
+
+    otherwise =>
+      #result error: (internal lift-http-error-reason: Response.reason request: self.request);
+  end
+end

--- a/stdlib/crochet.wrapper.browser.web-apis/source/internal.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/internal.crochet
@@ -1,0 +1,7 @@
+% crochet
+
+singleton internal;
+capability internal;
+
+protect type internal with internal;
+protect global internal with internal;

--- a/stdlib/crochet.wrapper.browser.web-apis/source/internal.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/internal.crochet
@@ -1,7 +1,0 @@
-% crochet
-
-singleton internal;
-capability internal;
-
-protect type internal with internal;
-protect global internal with internal;


### PR DESCRIPTION
A basic wrapper over Browser's `fetch`. Currently only supports textual requests and responses because Crochet does not have anything to represent binary data yet.

This patch incidentally also fixes a bunch of other annoying and unrelated things, like run-web not asking for capabilities interactively and just presenting you with an error page saying you didn't grant it any of the required capabilities.