### PR TITLE
Intrinsic internal capability and package type

### DIFF
--- a/examples/agata/todo-list/crochet.json
+++ b/examples/agata/todo-list/crochet.json
@@ -15,12 +15,15 @@
   "dependencies": [
     "crochet.core",
     "crochet.concurrency",
-    "crochet.ui.agata",
+    {
+      "name": "crochet.ui.agata",
+      "capabilities": ["crochet.core/asset-location"]
+    },
     "crochet.time",
     "crochet.debug"
   ],
   "capabilities": {
-    "requires": ["crochet.ui.agata/ui-control"],
+    "requires": ["crochet.ui.agata/ui-control", "crochet.core/asset-location"],
     "provides": []
   }
 }

--- a/examples/agata/widget-gallery/crochet.json
+++ b/examples/agata/widget-gallery/crochet.json
@@ -9,9 +9,21 @@
     "source/layout/section.crochet",
     "source/layout/card.crochet"
   ],
-  "dependencies": ["crochet.core", "crochet.concurrency", "crochet.ui.agata"],
+  "dependencies": [
+    "crochet.core",
+    "crochet.concurrency",
+    {
+      "name": "crochet.ui.agata",
+      "capabilities": ["crochet.core/asset-location"]
+    }
+  ],
   "capabilities": {
-    "requires": ["crochet.ui.agata/ui-control", "crochet.ui.agata/network"],
+    "requires": [
+      "crochet.ui.agata/ui-control",
+      "crochet.ui.agata/network",
+      "crochet.core/asset-location"
+    ],
     "provides": []
-  }
+  },
+  "assets": ["img/sun.png"]
 }

--- a/examples/agata/widget-gallery/source/layout/card.crochet
+++ b/examples/agata/widget-gallery/source/layout/card.crochet
@@ -33,7 +33,7 @@ command layout-card page do
       #widget space | vertical: (3.0 as rem),
 
       #widget card: [
-        #card-child image: (agata-network image: "/assets/crochet.examples.agata.widget-gallery/img/sun.png"),
+        #card-child image: (#image from-asset: (package assets at: "img/sun.png")),
         #card-child header: "A sunny Stockholm",
         #card-child meta: "10 minutes ago",
         #card-child body: [

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "immutable": "^4.0.0-rc.14",
-    "ohm-js": "^15.3.0",
-    "uuid": "^8.3.2"
+    "ohm-js": "^15.3.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.11",

--- a/source/crochet/crochet.ts
+++ b/source/crochet/crochet.ts
@@ -242,7 +242,7 @@ export class BootedCrochet {
 
   private async load_package(pkg: Package.ResolvedPackage) {
     logger.debug(`Loading package ${pkg.name}`);
-    const cpkg = VM.World.get_or_make_package(this.universe.world, pkg);
+    const cpkg = VM.World.get_or_make_package(this.universe, pkg);
 
     if (!this.crochet.safe_mode) {
       for (const x of pkg.native_sources) {

--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -46,7 +46,7 @@ import {
   Universe,
   Values,
 } from "../vm";
-import * as UUID from "uuid";
+import { random_uuid } from "../utils/uuid";
 
 export type { Machine, CrochetValue };
 export type { ISet, IList, IMap };
@@ -424,7 +424,7 @@ export class ForeignInterface {
   }
 
   uuid4() {
-    return UUID.v4();
+    return random_uuid();
   }
 
   // == Tracing (only exposed for debug package)

--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -264,6 +264,11 @@ export class ForeignInterface {
     }
   }
 
+  get_underlying_package(x: CrochetValue) {
+    Values.assert_tag(Tag.ANY_PACKAGE, x);
+    return x.payload;
+  }
+
   // == Operations
   intrinsic_equals(x: CrochetValue, y: CrochetValue) {
     return Values.equals(x, y);

--- a/source/node-cli/docs.ts
+++ b/source/node-cli/docs.ts
@@ -26,6 +26,7 @@ import {
 } from "../vm/primitives/location";
 import { get_annotated_source, get_source_slice } from "../vm/primitives/meta";
 import type * as Express from "express";
+import { random_uuid } from "../utils/uuid";
 
 const doc_root = Path.resolve(__dirname, "../../tools/docs");
 const www_root = Path.resolve(__dirname, "../../www");
@@ -82,7 +83,14 @@ export async function serve_docs(
   filename: string,
   target0: Package.Target | null
 ) {
-  const crochet = new CrochetForNode(false, [], new Set([]), false, true);
+  const crochet = new CrochetForNode(
+    { universe: random_uuid(), packages: new Map() },
+    false,
+    [],
+    new Set([]),
+    false,
+    true
+  );
   const pkg = crochet.read_package_from_file(filename);
   const target = target0 ?? pkg.meta.target;
   await crochet.boot(pkg, target);

--- a/source/node-cli/index.ts
+++ b/source/node-cli/index.ts
@@ -18,6 +18,7 @@ import * as ChildProcess from "child_process";
 import { serve_docs } from "./docs";
 import { Ok, try_parse } from "../utils/spec";
 import { StorageConfig } from "../storage";
+import { random_uuid } from "../utils/uuid";
 
 function read_crochet(file: string) {
   const source = FS.readFileSync(file, "utf-8");
@@ -263,6 +264,7 @@ async function show_ir([file]: string[], options: Options) {
 
 async function run([file]: string[], options: Options) {
   const crochet = new CrochetForNode(
+    { universe: random_uuid(), packages: new Map() },
     options.disclose_debug,
     [],
     options.capabilities,
@@ -282,6 +284,7 @@ async function run([file]: string[], options: Options) {
 
 async function test([file]: string[], options: Options) {
   const crochet = new CrochetForNode(
+    { universe: random_uuid(), packages: new Map() },
     options.disclose_debug,
     [],
     options.capabilities,
@@ -298,6 +301,7 @@ async function test([file]: string[], options: Options) {
 
 async function build([file]: string[], options: Options) {
   const crochet = new CrochetForNode(
+    { universe: random_uuid(), packages: new Map() },
     options.disclose_debug,
     [],
     new Set([]),
@@ -309,6 +313,7 @@ async function build([file]: string[], options: Options) {
 
 async function repl([file0]: string[], options: Options) {
   const crochet = new CrochetForNode(
+    { universe: random_uuid(), packages: new Map() },
     options.disclose_debug,
     [],
     new Set([]),
@@ -324,6 +329,7 @@ async function repl([file0]: string[], options: Options) {
 
 async function run_web([file]: string[], options: Options) {
   const crochet = new CrochetForNode(
+    { universe: random_uuid(), packages: new Map() },
     options.disclose_debug,
     [],
     new Set([]),

--- a/source/node-cli/package.ts
+++ b/source/node-cli/package.ts
@@ -3,6 +3,7 @@ import * as FS from "fs";
 import * as Package from "../pkg";
 import { CrochetForNode, build, build_file } from "../targets/node";
 import { unreachable } from "../utils/utils";
+import { random_uuid } from "../utils/uuid";
 
 export enum PackageType {
   BROWSER,
@@ -26,7 +27,14 @@ export async function package_app(
   target0: Package.Target | null,
   out_dir0: string
 ) {
-  const crochet = new CrochetForNode(false, [], new Set([]), false, false);
+  const crochet = new CrochetForNode(
+    { universe: random_uuid(), packages: new Map() },
+    false,
+    [],
+    new Set([]),
+    false,
+    false
+  );
   const pkg = crochet.read_package_from_file(filename);
   const out_dir = Path.join(out_dir0, pkg.meta.name);
   const target = target0 ?? pkg.meta.target;

--- a/source/pkg/graph.ts
+++ b/source/pkg/graph.ts
@@ -9,6 +9,7 @@ import {
   restrict_capabilities,
   target_compatible,
 } from "./ops";
+import { target_any } from ".";
 
 export interface IPackageResolution {
   get_package(name: string): Promise<Package>;
@@ -335,6 +336,10 @@ export class ResolvedPackage {
   get provided_capabilities() {
     const provided = [...this.pkg.meta.capabilities.provides];
     return new Set(provided.map((x) => `${this.name}/${x.name}`));
+  }
+
+  get assets() {
+    return this.pkg.meta.assets;
   }
 }
 

--- a/source/pkg/ir.ts
+++ b/source/pkg/ir.ts
@@ -4,6 +4,7 @@ export type PackageMeta = {
   readonly sources: File[];
   readonly native_sources: File[];
   readonly dependencies: Dependency[];
+  readonly assets: Asset[];
   readonly capabilities: Capabilities;
 };
 export type Package = {
@@ -48,6 +49,10 @@ export type Capabilities = {
   readonly provides: Set<ProvideCapability>;
 };
 
+export type Asset = {
+  readonly path: string;
+};
+
 export type ProvideCapability = {
   name: string;
   description: string;
@@ -86,5 +91,9 @@ export function provide_capability(x: ProvideCapability): ProvideCapability {
 }
 
 export function capabilities(x: Capabilities): Capabilities {
+  return x;
+}
+
+export function asset(x: Asset): Asset {
   return x;
 }

--- a/source/pkg/parser.ts
+++ b/source/pkg/parser.ts
@@ -22,7 +22,7 @@ import {
   string,
 } from "../utils/spec";
 import * as Spec from "../utils/spec";
-import { provide_capability } from ".";
+import { asset, provide_capability } from ".";
 
 function set<T>(x: AnySpec<T>) {
   return map_spec(array(x), (xs) => new Set(xs));
@@ -86,6 +86,12 @@ export const dependency_spec = anyOf([
   ),
 ]);
 
+export const asset_spec = anyOf([
+  map_spec(string, (x) => {
+    return asset({ path: x });
+  }),
+]);
+
 export const package_spec = spec(
   {
     name: string,
@@ -93,6 +99,7 @@ export const package_spec = spec(
     sources: array(file_spec),
     native_sources: optional(array(file_spec), []),
     dependencies: optional(array(dependency_spec), []),
+    assets: optional(array(asset_spec), []),
     capabilities: optional(
       capabilities_spec,
       capabilities({

--- a/source/targets/bench.ts
+++ b/source/targets/bench.ts
@@ -1,4 +1,5 @@
 import * as Package from "../pkg";
+import { random_uuid } from "../utils/uuid";
 import { CrochetForNode } from "./node";
 
 export class CrochetForBench extends CrochetForNode {
@@ -6,7 +7,14 @@ export class CrochetForBench extends CrochetForNode {
     readonly _sdtlib_path: string,
     readonly capabilities: Set<Package.Capability>
   ) {
-    super(true, [], capabilities, false, false);
+    super(
+      { universe: random_uuid(), packages: new Map() },
+      true,
+      [],
+      capabilities,
+      false,
+      false
+    );
   }
 
   get stdlib_path() {

--- a/source/targets/browser/browser.ts
+++ b/source/targets/browser/browser.ts
@@ -16,6 +16,7 @@ import {
 import { CrochetValue, CrochetTest } from "../../vm";
 import { EventStream } from "../../utils/event";
 import { defer } from "../../utils/utils";
+import { random_uuid } from "../../utils/uuid";
 
 export class CrochetForBrowser {
   readonly crochet: Crochet;
@@ -25,11 +26,12 @@ export class CrochetForBrowser {
   readonly test_report = new EventStream<TestReportMessage>();
 
   constructor(
+    token: { universe: string; packages: Map<string, string> },
     readonly library_base: string,
     readonly capabilities: Set<Package.Capability>,
     readonly interactive: boolean
   ) {
-    this.crochet = new Crochet(false, this.fs, this.signal);
+    this.crochet = new Crochet(token, false, this.fs, this.signal);
   }
 
   get system() {

--- a/source/targets/node/node.ts
+++ b/source/targets/node/node.ts
@@ -21,6 +21,7 @@ import {
   TraceEvent,
   Location,
 } from "../../vm";
+import { random_uuid } from "../../utils/uuid";
 
 const rootRelative = process.env.WEBPACK ? "" : "../../../";
 
@@ -31,13 +32,14 @@ export class CrochetForNode {
   private _ffi: ForeignInterface | null = null;
 
   constructor(
+    token: { universe: string; packages: Map<string, string> },
     disclose_debug: boolean,
     readonly library_paths: string[],
     readonly capabilities: Set<Package.Capability>,
     readonly interactive: boolean,
     readonly safe_mode: boolean
   ) {
-    this.crochet = new Crochet(safe_mode, this.fs, this.signal);
+    this.crochet = new Crochet(token, safe_mode, this.fs, this.signal);
   }
 
   render_entry = (entry: TraceEvent) => {

--- a/source/utils/uuid.ts
+++ b/source/utils/uuid.ts
@@ -1,0 +1,8 @@
+export function random_uuid(): string {
+  if (typeof window != "undefined") {
+    return (crypto as any).randomUUID();
+  } else {
+    const crypto = "crypto";
+    return require(crypto).randomUUID();
+  }
+}

--- a/source/vm/boot.ts
+++ b/source/vm/boot.ts
@@ -33,7 +33,7 @@ import {
 import { Contexts } from "./simulation";
 import { CrochetTrace } from "./tracing";
 
-export function make_universe() {
+export function make_universe(token: string) {
   const world = new CrochetWorld();
 
   // Core types
@@ -322,7 +322,7 @@ export function make_universe() {
   world.native_types.define("crochet.core/core.action-choice", ActionChoice);
   world.native_types.define("crochet.core/core.package", Package);
 
-  return new Universe(new CrochetTrace(), world, XorShift.new_random(), {
+  return new Universe(token, new CrochetTrace(), world, XorShift.new_random(), {
     Any,
     Unknown,
     Protected,

--- a/source/vm/boot.ts
+++ b/source/vm/boot.ts
@@ -274,6 +274,18 @@ export function make_universe() {
     null
   );
 
+  // Packages
+  const Package = new CrochetType(
+    null,
+    "any-package",
+    "",
+    Any,
+    [],
+    [],
+    false,
+    null
+  );
+
   world.native_types.define("crochet.core/core.static-type", Type);
   world.native_types.define("crochet.core/core.any", Any);
   world.native_types.define("crochet.core/core.protected", Protected);
@@ -308,6 +320,7 @@ export function make_universe() {
   world.native_types.define("crochet.core/core.action", Action);
   world.native_types.define("crochet.core/core.action", Action);
   world.native_types.define("crochet.core/core.action-choice", ActionChoice);
+  world.native_types.define("crochet.core/core.package", Package);
 
   return new Universe(new CrochetTrace(), world, XorShift.new_random(), {
     Any,
@@ -335,6 +348,7 @@ export function make_universe() {
     Action,
     ActionChoice,
     Effect,
+    Package,
   });
 }
 

--- a/source/vm/intrinsics.ts
+++ b/source/vm/intrinsics.ts
@@ -5,7 +5,7 @@ import { Namespace, PassthroughNamespace } from "./namespaces";
 // Only imported so callbacks get the correct type here
 import type { Pattern } from "./logic/unification";
 import type { CrochetTrace } from "./tracing/trace";
-import { hash, isImmutable } from "immutable";
+import type { ResolvedPackage } from "../pkg";
 
 export type Primitive = boolean | null | bigint | number;
 
@@ -378,12 +378,14 @@ export class CrochetPackage {
   readonly capabilities: PassthroughNamespace<CrochetCapability>;
   readonly dependencies = new Set<string>();
   readonly granted_capabilities = new Set<CrochetCapability>();
+  private _token: string;
 
   constructor(
     readonly world: CrochetWorld,
-    readonly name: string,
-    readonly filename: string
+    readonly metadata: ResolvedPackage
   ) {
+    this._token = "";
+    const name = this.metadata.name;
     this.missing_traits = new Namespace(null, null, null);
     this.missing_types = new Namespace(null, null, null);
     this.missing_capabilities = new Namespace(null, null, null);
@@ -395,6 +397,22 @@ export class CrochetPackage {
     this.actions = new PassthroughNamespace(world.actions, name);
     this.contexts = new PassthroughNamespace(world.contexts, name);
     this.capabilities = new PassthroughNamespace(world.capabilities, name);
+  }
+
+  get name() {
+    return this.metadata.name;
+  }
+
+  get filename() {
+    return this.metadata.filename;
+  }
+
+  set_token(token: string) {
+    this._token = token;
+  }
+
+  get token() {
+    return this._token;
   }
 }
 
@@ -941,6 +959,7 @@ export class Universe {
   readonly trusted_base = new Set<CrochetPackage>();
 
   constructor(
+    readonly token: string,
     readonly trace: CrochetTrace,
     readonly world: CrochetWorld,
     readonly random: XorShift,

--- a/source/vm/intrinsics.ts
+++ b/source/vm/intrinsics.ts
@@ -31,6 +31,7 @@ export enum Tag {
   ACTION_CHOICE,
   UNKNOWN,
   PROTECTED,
+  ANY_PACKAGE,
 }
 
 export type PayloadType = {
@@ -54,6 +55,7 @@ export type PayloadType = {
   [Tag.ACTION_CHOICE]: ActionChoice;
   [Tag.UNKNOWN]: unknown;
   [Tag.PROTECTED]: CrochetProtectedValue;
+  [Tag.ANY_PACKAGE]: CrochetPackage;
 };
 
 export interface ActionChoice {
@@ -968,6 +970,7 @@ export class Universe {
       Action: CrochetType;
       ActionChoice: CrochetType;
       Effect: CrochetType;
+      Package: CrochetType;
     }
   ) {
     this.nothing = new CrochetValue(Tag.NOTHING, types.Nothing, null);

--- a/source/vm/primitives/location.ts
+++ b/source/vm/primitives/location.ts
@@ -214,6 +214,10 @@ export function simple_value(x: CrochetValue): string {
       assert_tag(Tag.PROTECTED, x);
       return `<protected ${simple_value(x.payload.value)}>`;
     }
+    case Tag.ANY_PACKAGE: {
+      assert_tag(Tag.ANY_PACKAGE, x);
+      return `<package ${x.payload.name}>`;
+    }
     default:
       throw unreachable(x.tag, `Value ${x}`);
   }

--- a/source/vm/primitives/packages.ts
+++ b/source/vm/primitives/packages.ts
@@ -1,5 +1,15 @@
+import { CrochetCapability, CrochetModule, CrochetType } from "..";
+import { Visibility } from "../../ir";
 import { ErrArbitrary } from "../errors";
 import { CrochetPackage, Universe } from "../intrinsics";
+import {
+  define_capability,
+  protect_definition,
+  protect_type,
+} from "./capability";
+import { define } from "./modules";
+import { define_type, seal } from "./types";
+import { instantiate, make_package_value } from "./values";
 
 export function is_open_allowed(pkg: CrochetPackage, namespace: string) {
   return pkg.dependencies.has(namespace);
@@ -12,4 +22,36 @@ export function assert_open_allowed(pkg: CrochetPackage, namespace: string) {
       `Cannot open name ${namespace} from ${pkg.name} because it's not declared as a dependency`
     );
   }
+}
+
+export function initialise_types(universe: Universe, pkg: CrochetPackage) {
+  const internal_module = new CrochetModule(pkg, "(internal)", null);
+
+  // Internal type
+  const package_type = new CrochetType(
+    internal_module,
+    "package",
+    "",
+    universe.types.Package,
+    [],
+    [],
+    false,
+    null
+  );
+  const package_value = make_package_value(universe, package_type, pkg);
+  seal(package_type);
+  define_type(internal_module, "package", package_type, Visibility.GLOBAL);
+  define(internal_module, Visibility.GLOBAL, "package", package_value);
+
+  // Internal capability
+  const internal_cap = new CrochetCapability(
+    internal_module,
+    "internal",
+    "Definitions internal to this package.",
+    null
+  );
+  define_capability(internal_module, internal_cap);
+
+  protect_type(universe, internal_module, "package", internal_cap);
+  protect_definition(universe, internal_module, "package", internal_cap);
 }

--- a/source/vm/primitives/values.ts
+++ b/source/vm/primitives/values.ts
@@ -1,4 +1,4 @@
-import { CrochetCapability, CrochetProtectedValue } from "..";
+import { CrochetCapability, CrochetPackage, CrochetProtectedValue } from "..";
 import * as IR from "../../ir";
 import { clone_map, zip, zip3 } from "../../utils/utils";
 import { ErrArbitrary } from "../errors";
@@ -55,6 +55,14 @@ export function make_static_text(universe: Universe, x: string) {
 
 export function make_list(universe: Universe, xs: CrochetValue[]) {
   return new CrochetValue(Tag.LIST, universe.types.List, xs);
+}
+
+export function make_package_value(
+  universe: Universe,
+  type: CrochetType,
+  pkg: CrochetPackage
+) {
+  return new CrochetValue(Tag.ANY_PACKAGE, type, pkg);
 }
 
 export function make_interpolation(

--- a/source/vm/primitives/world.ts
+++ b/source/vm/primitives/world.ts
@@ -17,7 +17,7 @@ export function get_or_make_package(universe: Universe, pkg: ResolvedPackage) {
   if (result != null) {
     return result;
   } else {
-    const cpkg = new CrochetPackage(world, pkg.name, pkg.filename);
+    const cpkg = new CrochetPackage(world, pkg);
     for (const dep of pkg.dependencies) {
       cpkg.dependencies.add(dep.name);
     }

--- a/source/vm/primitives/world.ts
+++ b/source/vm/primitives/world.ts
@@ -1,11 +1,18 @@
 import { ResolvedPackage } from "../../pkg";
-import { CrochetPackage, CrochetPrelude, CrochetWorld } from "../intrinsics";
+import * as Packages from "./packages";
+import {
+  CrochetPackage,
+  CrochetPrelude,
+  CrochetWorld,
+  Universe,
+} from "../intrinsics";
 
 export function add_prelude(world: CrochetWorld, prelude: CrochetPrelude) {
   world.prelude.push(prelude);
 }
 
-export function get_or_make_package(world: CrochetWorld, pkg: ResolvedPackage) {
+export function get_or_make_package(universe: Universe, pkg: ResolvedPackage) {
+  const world = universe.world;
   const result = world.packages.get(pkg.name);
   if (result != null) {
     return result;
@@ -14,6 +21,7 @@ export function get_or_make_package(world: CrochetWorld, pkg: ResolvedPackage) {
     for (const dep of pkg.dependencies) {
       cpkg.dependencies.add(dep.name);
     }
+    Packages.initialise_types(universe, cpkg);
     world.packages.set(pkg.name, cpkg);
     return cpkg;
   }

--- a/stdlib/crochet.concurrency/source/internal.crochet
+++ b/stdlib/crochet.concurrency/source/internal.crochet
@@ -1,7 +1,6 @@
 % crochet
 
 singleton internal;
-capability internal;
 
 protect global internal with internal;
 protect type internal with internal;

--- a/stdlib/crochet.core/crochet.json
+++ b/stdlib/crochet.core/crochet.json
@@ -111,10 +111,19 @@
     "source/traits/sequence.crochet",
     "source/traits/set-algebra.crochet",
 
-    "source/package/core.crochet"
+    "source/package/core.crochet",
+    "source/package/assets.crochet",
+    {
+      "filename": "source/package/location-browser.crochet",
+      "target": "browser"
+    },
+    {
+      "filename": "source/package/location-node.crochet",
+      "target": "node"
+    }
   ],
   "capabilities": {
     "requires": [],
-    "provides": ["tainting", "untainting"]
+    "provides": ["tainting", "untainting", "asset-location"]
   }
 }

--- a/stdlib/crochet.core/crochet.json
+++ b/stdlib/crochet.core/crochet.json
@@ -16,7 +16,8 @@
     "native/set.js",
     "native/seal.js",
     "native/map.js",
-    "native/fun.js"
+    "native/fun.js",
+    "native/pkg.js"
   ],
   "sources": [
     "source/0-types.crochet",
@@ -108,7 +109,9 @@
     "source/traits/iteration.crochet",
     "source/traits/ordering.crochet",
     "source/traits/sequence.crochet",
-    "source/traits/set-algebra.crochet"
+    "source/traits/set-algebra.crochet",
+
+    "source/package/core.crochet"
   ],
   "capabilities": {
     "requires": [],

--- a/stdlib/crochet.core/native/pkg.ts
+++ b/stdlib/crochet.core/native/pkg.ts
@@ -1,8 +1,45 @@
 import type { ForeignInterface } from "../../../build/crochet";
+import { Universe } from "../../../build/vm";
 
 export default (ffi: ForeignInterface) => {
   ffi.defun("pkg.name", (x) => {
     const pkg = ffi.get_underlying_package(x);
     return ffi.text(pkg.name);
+  });
+
+  ffi.defun("pkg.asset", (pkg0, path0) => {
+    const pkg = ffi.get_underlying_package(pkg0);
+    const path = ffi.text_to_string(path0);
+    const asset = pkg.metadata.assets.find((x) => x.path);
+    if (asset == null) {
+      throw ffi.panic("invalid-asset", `No asset ${path}`);
+    }
+    return ffi.text(asset.path);
+  });
+
+  ffi.defun("pkg.asset-location-node", (pkg0, path0) => {
+    const pkg = ffi.get_underlying_package(pkg0);
+    const path = ffi.text_to_string(path0);
+    const full_path = require("path").resolve(pkg.metadata.assets_root, path);
+    if (!full_path.startsWith(pkg.metadata.assets_root)) {
+      throw ffi.panic(
+        "invalid-asset",
+        `Asset ${path} does not have a valid path`
+      );
+    }
+    return ffi.text(full_path);
+  });
+
+  ffi.defmachine("pkg.asset-location-web", function* (pkg0, path0) {
+    const pkg = ffi.get_underlying_package(pkg0);
+    const path = decodeURI(ffi.text_to_string(path0));
+    if (/\b\.\.\b/.test(path)) {
+      throw ffi.panic(
+        "invalid-asset",
+        `Asset ${path} does not have a valid path`
+      );
+    }
+    const full_path = `assets/${pkg.token}/${path}`;
+    return ffi.text(full_path);
   });
 };

--- a/stdlib/crochet.core/native/pkg.ts
+++ b/stdlib/crochet.core/native/pkg.ts
@@ -1,0 +1,8 @@
+import type { ForeignInterface } from "../../../build/crochet";
+
+export default (ffi: ForeignInterface) => {
+  ffi.defun("pkg.name", (x) => {
+    const pkg = ffi.get_underlying_package(x);
+    return ffi.text(pkg.name);
+  });
+};

--- a/stdlib/crochet.core/source/0-types.crochet
+++ b/stdlib/crochet.core/source/0-types.crochet
@@ -16,9 +16,6 @@ capability untainting;
 /// Allows constructing mutable memory cells.
 capability mutability;
 
-/// Used for internal types.
-capability internal;
-
 singleton internal;
 protect type internal with internal;
 protect global internal with internal;

--- a/stdlib/crochet.core/source/package/assets.crochet
+++ b/stdlib/crochet.core/source/package/assets.crochet
@@ -1,0 +1,17 @@
+% crochet
+
+capability asset-location;
+singleton asset-location;
+protect type asset-location with asset-location;
+protect global asset-location with asset-location;
+
+
+type package-assets(pkg is any-package);
+type package-asset(pkg is any-package, path is text);
+
+command package-assets at: (Path is static-text) =
+  new package-asset(self.pkg, foreign pkg.asset(self.pkg, Path));
+
+
+
+

--- a/stdlib/crochet.core/source/package/core.crochet
+++ b/stdlib/crochet.core/source/package/core.crochet
@@ -4,3 +4,6 @@ type any-package = foreign core.package;
 
 command any-package name =
   foreign pkg.name(self);
+
+command any-package assets =
+  new package-assets(self);

--- a/stdlib/crochet.core/source/package/core.crochet
+++ b/stdlib/crochet.core/source/package/core.crochet
@@ -1,0 +1,6 @@
+% crochet
+
+type any-package = foreign core.package;
+
+command any-package name =
+  foreign pkg.name(self);

--- a/stdlib/crochet.core/source/package/location-browser.crochet
+++ b/stdlib/crochet.core/source/package/location-browser.crochet
@@ -1,0 +1,4 @@
+% crochet
+
+command asset-location resolve: (Asset is package-asset) =
+  foreign pkg.asset-location-web(Asset.pkg, Asset.path);

--- a/stdlib/crochet.core/source/package/location-node.crochet
+++ b/stdlib/crochet.core/source/package/location-node.crochet
@@ -1,0 +1,4 @@
+% crochet
+
+command asset-location resolve: (Asset is package-asset) =
+  foreign pkg.asset-location-node(Asset.pkg, Asset.path);

--- a/stdlib/crochet.debug.tracing/source/types.crochet
+++ b/stdlib/crochet.debug.tracing/source/types.crochet
@@ -4,7 +4,6 @@ open crochet.debug;
 
 singleton internal;
 
-capability internal;
 protect global internal with internal;
 protect type internal with internal;
 

--- a/stdlib/crochet.debug/source/types.crochet
+++ b/stdlib/crochet.debug/source/types.crochet
@@ -1,6 +1,5 @@
 % crochet
 
 singleton debug-internal;
-capability internal;
 protect type debug-internal with internal;
 protect global debug-internal with internal;

--- a/stdlib/crochet.language.json/source/capabilities.crochet
+++ b/stdlib/crochet.language.json/source/capabilities.crochet
@@ -1,7 +1,7 @@
 % crochet
 
 singleton internal;
-capability internal;
 
 protect type internal with internal;
 protect global internal with internal;
+

--- a/stdlib/crochet.network.types/source/internal.crochet
+++ b/stdlib/crochet.network.types/source/internal.crochet
@@ -1,7 +1,6 @@
 % crochet
 
 singleton internal;
-capability internal;
 
 protect type internal with internal;
 protect global internal with internal;

--- a/stdlib/crochet.ui.agata/crochet.json
+++ b/stdlib/crochet.ui.agata/crochet.json
@@ -90,7 +90,7 @@
     "crochet.text.parsing.lingua"
   ],
   "capabilities": {
-    "requires": [],
+    "requires": ["crochet.core/asset-location"],
     "provides": ["network", "ui-control", "arbitrary-fonts", "arbitrary-css"]
   }
 }

--- a/stdlib/crochet.ui.agata/source/capabilities.crochet
+++ b/stdlib/crochet.ui.agata/source/capabilities.crochet
@@ -1,6 +1,4 @@
 % crochet
-  
-capability internal;
 
 singleton internal;
 protect global internal with internal;

--- a/stdlib/crochet.ui.agata/source/core/image.crochet
+++ b/stdlib/crochet.ui.agata/source/core/image.crochet
@@ -5,6 +5,7 @@ open crochet.concurrency;
 abstract image;
 
 type network-image(uri is text) is image;
+type asset-image(asset is package-asset) is image;
 
 abstract network-error;
 type arbitrary-network-error(image is network-image) is network-error;
@@ -16,3 +17,7 @@ command network-image preload do
     otherwise => #result error: new arbitrary-network-error(self);
   end
 end
+
+
+command #image from-asset: (Asset is package-asset) =
+  new asset-image(Asset);

--- a/stdlib/crochet.ui.agata/source/dom/renderer/image.crochet
+++ b/stdlib/crochet.ui.agata/source/dom/renderer/image.crochet
@@ -2,3 +2,6 @@
 
 command dom-renderer to-uri: (Image is network-image) =
   Image.uri;
+
+command dom-renderer to-uri: (Image is asset-image) =
+  asset-location resolve: Image.asset;

--- a/stdlib/crochet.ui.agata/source/widget/layout/card.crochet
+++ b/stdlib/crochet.ui.agata/source/widget/layout/card.crochet
@@ -38,7 +38,7 @@ end
 command #card-child image: (X is widget-image) =
   new card-child-image(X);
 
-command #card-child image: (X is network-image) =
+command #card-child image: (X is image) =
   self image: (#widget image: X);
 
 command #card-child header: (X has to-widget) =

--- a/stdlib/crochet.wrapper.browser.web-apis/source/capabilities.crochet
+++ b/stdlib/crochet.wrapper.browser.web-apis/source/capabilities.crochet
@@ -1,7 +1,6 @@
 % crochet
 
 singleton internal;
-capability internal;
 
 protect type internal with internal;
 protect global internal with internal;

--- a/tests/vm-tests/crochet.json
+++ b/tests/vm-tests/crochet.json
@@ -30,6 +30,7 @@
     "feature/effects.crochet",
     "feature/traits.crochet",
     "feature/capabilities.crochet",
+    "feature/internal.crochet",
     "regression/placeholder-dispatch.crochet"
   ],
   "capabilities": {

--- a/tests/vm-tests/feature/internal.crochet
+++ b/tests/vm-tests/feature/internal.crochet
@@ -1,0 +1,10 @@
+% crochet
+
+test "Internal packages are defined by the VM" do
+  assert package name =:= "crochet.internal.vm.tests";
+end
+
+
+// -- Internal capability exists without being defined here
+type internal-test;
+protect type internal-test with internal;

--- a/tools/launcher/source/app.ts
+++ b/tools/launcher/source/app.ts
@@ -18,7 +18,14 @@ export class App {
 
   async build() {
     console.log("Building all dependencies...");
-    const crochet = new CrochetForNode(false, [], new Set([]), false, true);
+    const crochet = new CrochetForNode(
+      { universe: "", packages: new Map() },
+      false,
+      [],
+      new Set([]),
+      false,
+      true
+    );
     await crochet.build(this.pkg.filename);
     for (const dep of this.pkg.meta.dependencies) {
       const dep_pkg = await crochet.fs.read_package(dep.name);
@@ -27,7 +34,14 @@ export class App {
   }
 
   async docs() {
-    const crochet = new CrochetForNode(false, [], new Set([]), false, true);
+    const crochet = new CrochetForNode(
+      { universe: "", packages: new Map() },
+      false,
+      [],
+      new Set([]),
+      false,
+      true
+    );
     const pkg = crochet.read_package_from_file(this.pkg.filename);
     const target = pkg.meta.target;
     await crochet.boot(pkg, target);

--- a/tools/launcher/source/client/client.ts
+++ b/tools/launcher/source/client/client.ts
@@ -23,6 +23,7 @@ export class Client {
 
   async instantiate() {
     const crochet = new Crochet.CrochetForBrowser(
+      { universe: "", packages: new Map() },
       `/${this.id}/library`,
       new Set(this.capabilities),
       false

--- a/www/index.html
+++ b/www/index.html
@@ -20,23 +20,28 @@
         <div class="crochet-loading-screen">Loading...</div>
       </div>
     </div>
+    <script id="crochet-config" type="text/plain">
+      {{crochet_config}}
+    </script>
     <script src="crochet.js"></script>
     <script>
       void (async function () {
+        const config_root = document.querySelector("#crochet-config");
+        const config = JSON.parse(config_root.textContent);
+        config_root.remove();
         const root = document.querySelector("#crochet");
-        const query = new URL(document.location.href).searchParams;
-        const capabilities = (query.get("capabilities") || "")
-          .split(",")
-          .map((x) => x.trim())
-          .filter((x) => x !== "");
         try {
           const crochet = new Crochet.CrochetForBrowser(
-            document.location.pathname + "library",
-            new Set(capabilities),
+            {
+              universe: config.token,
+              packages: new Map(Object.entries(config.package_tokens)),
+            },
+            config.library_root,
+            new Set(config.capabilities),
             false
           );
           await crochet.boot_from_file(
-            document.location.pathname + "app/crochet.json",
+            config.app_root,
             Crochet.Package.target_web()
           );
           root.classList.remove("crochet-loading");


### PR DESCRIPTION
The idea is that the package type and internal capability can be the standard way of sealing types and commands that are meant to be internal. The package type also provides programmatic access to package internal data---currently this is used to implement sandboxed file systems for each package---in the browser this is done by generating a set of routes with opaque tokens in them, this token is then granted to each package and used to generate the URL for each asset file.

There's quite a lot that still needs to be done to make this actually safe, but won't be done in this PR. Plus this change does highlight the need of adding support for optional capabilities before the stable release, as otherwise we're forced to grant strong capabilities just to load a package.

This patch also removes the dependency on uuid, as the only one we care about (random 128 bit UUID) is provided natively by both browsers and Node.