### PR TITLE
Support optional capabilities

### DIFF
--- a/examples/agata/todo-list/crochet.json
+++ b/examples/agata/todo-list/crochet.json
@@ -15,15 +15,12 @@
   "dependencies": [
     "crochet.core",
     "crochet.concurrency",
-    {
-      "name": "crochet.ui.agata",
-      "capabilities": ["crochet.core/asset-location"]
-    },
     "crochet.time",
-    "crochet.debug"
+    "crochet.debug",
+    "crochet.ui.agata"
   ],
   "capabilities": {
-    "requires": ["crochet.ui.agata/ui-control", "crochet.core/asset-location"],
+    "requires": ["crochet.ui.agata/ui-control"],
     "provides": []
   }
 }

--- a/examples/web-apis/ws-chat/crochet.json
+++ b/examples/web-apis/ws-chat/crochet.json
@@ -6,10 +6,7 @@
   "dependencies": [
     "crochet.core",
     "crochet.concurrency",
-    {
-      "name": "crochet.ui.agata",
-      "capabilities": ["crochet.core/asset-location"]
-    },
+    "crochet.ui.agata",
     "crochet.wrapper.browser.web-apis",
     "crochet.network.types",
     "crochet.language.json",
@@ -19,7 +16,6 @@
     "requires": [
       "crochet.wrapper.browser.web-apis/use-websockets",
       "crochet.wrapper.browser.web-apis/manage-websockets",
-      "crochet.core/asset-location",
       "crochet.ui.agata/ui-control"
     ],
     "provides": []

--- a/examples/web-apis/ws-chat/source/main.crochet
+++ b/examples/web-apis/ws-chat/source/main.crochet
@@ -161,7 +161,7 @@ command screen-login as widget do
         | fill-container-horizontally
         | with-margin: { M in M top: (1 as rem) }
     ]
-    | with-width: (500 as pixels)
+    | with-size: { S in S width: (500 as pixels) }
   ]
   | gap: (1 as rem)
   | justify-content: "center"

--- a/source/pkg/graph.ts
+++ b/source/pkg/graph.ts
@@ -145,6 +145,11 @@ export class PackageGraph {
       for (const x of pkg.required_capabilities) {
         pkg.granted_capabilities.add(x);
       }
+      for (const x of pkg.optional_capabilities) {
+        if (capabilities.has(x)) {
+          pkg.granted_capabilities.add(x);
+        }
+      }
 
       // check dependencies recursively
       for (const x of pkg.dependencies) {
@@ -152,7 +157,7 @@ export class PackageGraph {
         if (!visited.includes(dep)) {
           const new_capabilities = restrict_capabilities(
             capabilities,
-            dep.required_capabilities
+            dep.accepted_capabilities
           );
 
           check([dep, ...visited], name, dep, new_capabilities);
@@ -331,6 +336,14 @@ export class ResolvedPackage {
 
   get required_capabilities() {
     return this.pkg.meta.capabilities.requires;
+  }
+
+  get optional_capabilities() {
+    return this.pkg.meta.capabilities.optional;
+  }
+
+  get accepted_capabilities() {
+    return union(this.required_capabilities, this.optional_capabilities);
   }
 
   get provided_capabilities() {

--- a/source/pkg/ir.ts
+++ b/source/pkg/ir.ts
@@ -47,6 +47,7 @@ export type File = {
 export type Capabilities = {
   readonly requires: Set<Capability>;
   readonly provides: Set<ProvideCapability>;
+  readonly optional: Set<Capability>;
 };
 
 export type Asset = {

--- a/source/pkg/parser.ts
+++ b/source/pkg/parser.ts
@@ -64,6 +64,7 @@ export const capabilities_spec = spec(
   {
     requires: set(capability_spec),
     provides: set(capability_provide_spec),
+    optional: optional(set(capability_spec), new Set<Capability>()),
   },
   (x) => capabilities(x)
 );
@@ -105,6 +106,7 @@ export const package_spec = spec(
       capabilities({
         requires: new Set<Capability>(),
         provides: new Set<ProvideCapability>(),
+        optional: new Set<Capability>(),
       })
     ),
   },

--- a/stdlib/crochet.ui.agata/crochet.json
+++ b/stdlib/crochet.ui.agata/crochet.json
@@ -93,7 +93,8 @@
     "crochet.text.parsing.lingua"
   ],
   "capabilities": {
-    "requires": ["crochet.core/asset-location"],
-    "provides": ["network", "ui-control", "arbitrary-fonts", "arbitrary-css"]
+    "requires": [],
+    "provides": ["network", "ui-control", "arbitrary-fonts", "arbitrary-css"],
+    "optional": ["crochet.core/asset-location"]
   }
 }


### PR DESCRIPTION
This currently only allows packages to declare capabilities as optional and for parent packages to provide those capabilities, but all of the support for running/loading code based on which capabilities have been granted is missing. That needs to be done together with an improved support for the same for goal-based execution, which is planned but won't be making into 0.14 release.

Packages *need* to declare all capabilities they may use because Crochet will restrict the set of capabilities that can be propagated based on that, and it needs to communicate to the user what exactly is happening there. So this is essentially a trust/ux problem.