### PR TITLE
Display README text for root package in playground

### DIFF
--- a/source/crochet/crochet.ts
+++ b/source/crochet/crochet.ts
@@ -299,7 +299,12 @@ export class BootedCrochet {
       `Loading native module ${x.relative_filename} from package ${pkg.name}`
     );
     const module = await this.crochet.fs.read_native_module(x, pkg);
-    const ffi = new ForeignInterface(this.universe, cpkg, x.relative_filename);
+    const ffi = new ForeignInterface(
+      this,
+      this.universe,
+      cpkg,
+      x.relative_filename
+    );
     await module(ffi);
   }
 
@@ -390,5 +395,14 @@ export class BootedCrochet {
     perspectives: CrochetType[]
   ) {
     return debug_representations(this.universe, value, perspectives);
+  }
+
+  async readme(pkg0: Package.Package) {
+    try {
+      const pkg = this.graph.get_package(pkg0.meta.name);
+      return await this.crochet.fs.read_file(pkg.readme.absolute_filename);
+    } catch (e) {
+      return "";
+    }
   }
 }

--- a/source/crochet/crochet.ts
+++ b/source/crochet/crochet.ts
@@ -402,7 +402,7 @@ export class BootedCrochet {
       const pkg = this.graph.get_package(pkg0.meta.name);
       return await this.crochet.fs.read_file(pkg.readme.absolute_filename);
     } catch (e) {
-      return "";
+      return "(no welcome documentation)";
     }
   }
 }

--- a/source/crochet/foreign.ts
+++ b/source/crochet/foreign.ts
@@ -47,19 +47,27 @@ import {
   Values,
 } from "../vm";
 import { random_uuid } from "../utils/uuid";
+import { BootedCrochet } from "./crochet";
 
 export type { Machine, CrochetValue };
 export type { ISet, IList, IMap };
 
 export class ForeignInterface {
+  #vm: BootedCrochet;
   #universe: Universe;
   #package: CrochetPackage;
   #module: CrochetModule;
 
-  constructor(universe: Universe, pkg: CrochetPackage, filename: string) {
+  constructor(
+    vm: BootedCrochet,
+    universe: Universe,
+    pkg: CrochetPackage,
+    filename: string
+  ) {
     this.#universe = universe;
     this.#package = pkg;
     this.#module = new CrochetModule(pkg, filename, null);
+    this.#vm = vm;
   }
 
   defun(name: string, fn: (...args: CrochetValue[]) => CrochetValue) {
@@ -536,5 +544,9 @@ export class ForeignInterface {
 
   get formatter() {
     return Location;
+  }
+
+  get vm() {
+    return this.#vm;
   }
 }

--- a/source/node-cli/index.ts
+++ b/source/node-cli/index.ts
@@ -47,8 +47,11 @@ function read(file: string) {
   }
 }
 
-function run_electron(file: string, config: string = "") {
-  const child = ChildProcess.execFile(Electron as any, [file, config]);
+function run_electron(file: string, config?: string) {
+  const child = ChildProcess.execFile(
+    Electron as any,
+    [file, config as any].filter((x) => x != null)
+  );
   child.on("exit", (code) => {
     process.exit(code ?? 0);
   });

--- a/source/node-cli/playground-kernel.ts
+++ b/source/node-cli/playground-kernel.ts
@@ -3,11 +3,14 @@ import { contextBridge, ipcRenderer } from "electron";
 import * as REPL from "../node-repl";
 import * as Pkg from "../pkg";
 import * as Spec from "../utils/spec";
+import * as Path from "path";
+import * as FS from "fs";
+import * as OS from "os";
 
 let repl: REPL.NodeRepl | null = null;
 
 export interface Playground {
-  initialise(id: string): Promise<void>;
+  initialise(id: string, bare: boolean): Promise<void>;
   make_page(session_id: string): Promise<string>;
   run_code(
     session_id: string,
@@ -15,7 +18,9 @@ export interface Playground {
     language: string,
     code: string
   ): Promise<REPL.Representation[] | undefined>;
-  readme(): Promise<string>;
+  readme(session_id: string): Promise<string>;
+  update_root_readme(session_id: string, code: string): Promise<void>;
+  update_readme(session_id: string, pkg: string, code: string): Promise<void>;
 }
 
 declare var Playground: Playground;
@@ -29,17 +34,20 @@ function assert_repl(
   }
 }
 
+const configp = ipcRenderer.invoke("playground:get-config");
+
 contextBridge.exposeInMainWorld("Playground", <Playground>{
-  async initialise(id: string) {
+  async initialise(id: string, bare: boolean) {
     if (repl == null) {
-      const config = await ipcRenderer.invoke("playground:get-config");
+      const config = await configp;
       repl = await REPL.NodeRepl.bootstrap(
         config.root,
         Spec.parse(config.target, Pkg.target_spec),
         new Set(config.capabilities),
         randomUUID(),
         id,
-        new Map(config.package_tokens)
+        new Map(config.package_tokens),
+        bare
       );
     } else {
       throw new Error(`Playground is already initialised.`);
@@ -70,4 +78,25 @@ contextBridge.exposeInMainWorld("Playground", <Playground>{
     const result = await repl.vm.system.readme(root_pkg.pkg);
     return result;
   },
+
+  async update_root_readme(session_id: string, code: string) {
+    assert_repl(repl, session_id);
+    const root_pkg = repl.vm.system.graph.root;
+    const tmp_path = make_tmp_path();
+    FS.writeFileSync(tmp_path, code);
+    FS.renameSync(tmp_path, Path.resolve(root_pkg.readme.absolute_filename));
+  },
 });
+
+function make_tmp_path(retries = 10): string {
+  if (retries <= 0) {
+    throw new Error(`internal: failed to create temporary file`);
+  }
+
+  const path = Path.join(OS.tmpdir(), randomUUID());
+  if (!FS.existsSync(path)) {
+    return path;
+  } else {
+    return make_tmp_path(retries - 1);
+  }
+}

--- a/source/node-cli/server.ts
+++ b/source/node-cli/server.ts
@@ -1,7 +1,6 @@
 import * as Path from "path";
 import * as FS from "fs";
 import * as Package from "../pkg";
-import * as REPL from "../node-repl";
 import type * as Express from "express";
 import { CrochetForNode, build_file } from "../targets/node";
 import { random_uuid } from "../utils/uuid";
@@ -42,7 +41,6 @@ export default async (
 
   // -- Initialisation
   const session_id = randomUUID();
-  let repl: REPL.NodeRepl | null = null;
 
   const crochet = new CrochetForNode(
     { universe: random_uuid(), packages: new Map() },
@@ -158,17 +156,6 @@ export default async (
       console.log("Installing assets for", x.name);
       app.use(`/assets/${token}`, express.static(assets));
     }
-  }
-
-  if (target.tag === Package.TargetTag.NODE) {
-    repl = await REPL.NodeRepl.bootstrap(
-      root,
-      target,
-      capabilities,
-      randomUUID(),
-      session_id,
-      pkg_tokens
-    );
   }
 
   // -- Starting servers

--- a/source/node-cli/server.ts
+++ b/source/node-cli/server.ts
@@ -102,6 +102,10 @@ export default async (
     res.sendFile(Path.resolve(root));
   });
 
+  app.get("/app/README.md", async (req, res) => {
+    res.sendFile(Path.resolve(rpkg.readme.absolute_filename));
+  });
+
   async function try_build(res: Express.Response) {
     try {
       await crochet.build(root);

--- a/source/node-repl/repl.ts
+++ b/source/node-repl/repl.ts
@@ -95,12 +95,13 @@ export class NodeRepl {
     capabilities: Set<string>,
     universe: string,
     session: string,
-    package_tokens: Map<string, string>
+    package_tokens: Map<string, string>,
+    bare: boolean
   ) {
     const disclose_debug = false;
     const library_paths: string[] = [];
     const interactive = false;
-    const safe_mode = false;
+    const safe_mode = bare;
     const crochet = new CrochetForNode(
       { universe: universe, packages: package_tokens },
       disclose_debug,

--- a/source/pkg/graph.ts
+++ b/source/pkg/graph.ts
@@ -17,6 +17,7 @@ export interface IPackageResolution {
 
 export class PackageGraph {
   constructor(
+    readonly root: ResolvedPackage,
     readonly target: Target,
     readonly trusted: Set<Package>,
     readonly packages: Map<string, ResolvedPackage>
@@ -322,6 +323,13 @@ export class ResolvedPackage {
     );
   }
 
+  get readme() {
+    return new ResolvedFile(
+      this,
+      file({ filename: "README.md", target: target_any() })
+    );
+  }
+
   get sources() {
     return this.pkg.meta.sources
       .filter((x) => target_compatible(this.target, x.target))
@@ -383,5 +391,5 @@ export async function build_package_graph(
   const resolved_pkg = new ResolvedPackage(root, target);
   packages.set(resolved_pkg.name, resolved_pkg);
   await resolve(resolved_pkg);
-  return new PackageGraph(target, trusted, packages);
+  return new PackageGraph(resolved_pkg, target, trusted, packages);
 }

--- a/source/targets/browser/browser.ts
+++ b/source/targets/browser/browser.ts
@@ -75,6 +75,7 @@ export class CrochetForBrowser {
     this._root = root;
     this._booted_system = booted;
     this._ffi = new ForeignInterface(
+      this.system,
       this.system.universe,
       this.system.universe.world.packages.get(this.root.meta.name)!,
       this.root.filename

--- a/source/targets/browser/browser.ts
+++ b/source/targets/browser/browser.ts
@@ -143,6 +143,7 @@ export class CrochetForBrowser {
     read_package: async (name: string) => {
       const filename = this.package_url(name);
       const response = await fetch(filename);
+      throw_if_not_200(response, `package ${name}`);
       const data = await response.json();
       const pkg = Package.parse(data, filename);
       if (this.is_trusted(pkg)) {
@@ -153,6 +154,7 @@ export class CrochetForBrowser {
 
     read_file: async (file: string) => {
       const response = await fetch(file);
+      throw_if_not_200(response, `file ${file}`);
       return await response.text();
     },
 
@@ -161,6 +163,7 @@ export class CrochetForBrowser {
       pkg: Package.ResolvedPackage
     ) => {
       const response = await fetch(file.binary_image);
+      throw_if_not_200(response, `crochet binary ${file}`);
       const data = await response.arrayBuffer();
       const buffer = Buffer.from(data);
       return buffer;
@@ -171,6 +174,7 @@ export class CrochetForBrowser {
       pkg: Package.ResolvedPackage
     ) => {
       const response = await fetch(file.absolute_filename);
+      throw_if_not_200(response, `native module ${file}`);
       const source = await response.text();
       const exports = Object.create(null);
       const fn = new Function("exports", source);
@@ -204,4 +208,12 @@ export class CrochetForBrowser {
       this.test_report.publish(message);
     },
   };
+}
+
+function throw_if_not_200(response: Response, name: string) {
+  if (response.status === 404) {
+    throw new Error(`internal: resource not found: ${name}`);
+  } else if (response.status >= 400) {
+    throw new Error(`internal: failed to load resource: ${name}`);
+  }
 }

--- a/source/targets/node/node.ts
+++ b/source/targets/node/node.ts
@@ -95,6 +95,7 @@ export class CrochetForNode {
     this._root = root;
     this._booted_system = booted;
     this._ffi = new ForeignInterface(
+      this.system,
       this.system.universe,
       this.system.universe.world.packages.get(this.root.meta.name)!,
       this.root.filename

--- a/stdlib/crochet.debug.ui/crochet.json
+++ b/stdlib/crochet.debug.ui/crochet.json
@@ -11,8 +11,11 @@
     "source/playground/vm.crochet",
     "source/playground/errors.crochet",
     "source/playground/lens.crochet",
-    "source/ui/welcome.crochet",
+    "source/ui/frame.crochet",
+    "source/ui/loading.crochet",
     "source/ui/playground-page.crochet",
+    "source/ui/playground.crochet",
+    "source/ui/welcome.crochet",
     "source/main.crochet"
   ],
   "dependencies": [

--- a/stdlib/crochet.debug.ui/native/kernel.ts
+++ b/stdlib/crochet.debug.ui/native/kernel.ts
@@ -137,6 +137,7 @@ export default (ffi: ForeignInterface) => {
 
   abstract class BaseVM {
     abstract make_page(kernel: BaseKernel): Promise<BasePage>;
+    abstract readme(): Promise<string>;
   }
 
   class KernelVM extends BaseVM {
@@ -165,6 +166,11 @@ export default (ffi: ForeignInterface) => {
 
       return page;
     }
+
+    async readme() {
+      const root_pkg = this.vm.system.graph.root;
+      return await this.vm.system.readme(root_pkg.pkg);
+    }
   }
 
   class FarKernelVM extends BaseVM {
@@ -177,6 +183,10 @@ export default (ffi: ForeignInterface) => {
       const page = new FarKernelPage(this.session_id, id);
       kernel.add_page(page.page_id, page);
       return page;
+    }
+
+    async readme() {
+      return await Playground.readme();
     }
   }
 
@@ -384,5 +394,11 @@ export default (ffi: ForeignInterface) => {
         ])
       );
     }
+  });
+
+  ffi.defmachine("kernel.readme", function* (vm0) {
+    const vm = ffi.unbox_typed(BaseVM, vm0);
+    const text = yield ffi.await(vm.readme().then((x) => ffi.text(x)));
+    return text;
   });
 };

--- a/stdlib/crochet.debug.ui/native/kernel.ts
+++ b/stdlib/crochet.debug.ui/native/kernel.ts
@@ -138,10 +138,15 @@ export default (ffi: ForeignInterface) => {
   abstract class BaseVM {
     abstract make_page(kernel: BaseKernel): Promise<BasePage>;
     abstract readme(): Promise<string>;
+    abstract update_root_readme(code: string): Promise<void>;
   }
 
   class KernelVM extends BaseVM {
-    constructor(readonly id: string, readonly vm: CrochetForBrowser) {
+    constructor(
+      readonly kernel: BaseKernel,
+      readonly id: string,
+      readonly vm: CrochetForBrowser
+    ) {
       super();
     }
 
@@ -171,6 +176,10 @@ export default (ffi: ForeignInterface) => {
       const root_pkg = this.vm.system.graph.root;
       return await this.vm.system.readme(root_pkg.pkg);
     }
+
+    async update_root_readme(code: string) {
+      await Playground.update_root_readme(this.kernel.session_id, code);
+    }
   }
 
   class FarKernelVM extends BaseVM {
@@ -186,7 +195,11 @@ export default (ffi: ForeignInterface) => {
     }
 
     async readme() {
-      return await Playground.readme();
+      return await Playground.readme(this.session_id);
+    }
+
+    async update_root_readme(code: string): Promise<void> {
+      await Playground.update_root_readme(this.session_id, code);
     }
   }
 
@@ -244,6 +257,7 @@ export default (ffi: ForeignInterface) => {
       const universe = crypto.randomUUID();
       const session = crypto.randomUUID();
 
+      await Playground.initialise(this.session_id, true);
       const crochet = new Crochet.CrochetForBrowser(
         {
           universe: universe,
@@ -265,7 +279,7 @@ export default (ffi: ForeignInterface) => {
         return { ok: false, reason: result as string };
       }
 
-      const vm = new KernelVM(session, crochet);
+      const vm = new KernelVM(this, session, crochet);
       this.add_vm(session, vm);
 
       return { ok: true, value: vm };
@@ -277,7 +291,7 @@ export default (ffi: ForeignInterface) => {
       { ok: true; value: BaseVM } | { ok: false; reason: string }
     > {
       const id = crypto.randomUUID();
-      await Playground.initialise(this.session_id);
+      await Playground.initialise(this.session_id, false);
       const vm = new FarKernelVM(this.session_id, id);
       this.add_vm(id, vm);
       return { ok: true, value: vm };
@@ -400,5 +414,22 @@ export default (ffi: ForeignInterface) => {
     const vm = ffi.unbox_typed(BaseVM, vm0);
     const text = yield ffi.await(vm.readme().then((x) => ffi.text(x)));
     return text;
+  });
+
+  ffi.defmachine("kernel.update-root-readme", function* (vm0, code) {
+    const vm = ffi.unbox_typed(BaseVM, vm0);
+    try {
+      yield ffi.await(
+        vm.update_root_readme(ffi.text_to_string(code)).then((_) => ffi.nothing)
+      );
+      return ffi.record(new Map([["ok", ffi.boolean(true)]]));
+    } catch (e) {
+      return ffi.record(
+        new Map([
+          ["ok", ffi.boolean(false)],
+          ["reason", ffi.text(String(e))],
+        ])
+      );
+    }
   });
 };

--- a/stdlib/crochet.debug.ui/source/main.crochet
+++ b/stdlib/crochet.debug.ui/source/main.crochet
@@ -17,7 +17,7 @@ command playground-app
           config: (Config is record)
 do
   handle
-    agata show: new welcome-screen;
+    agata show: new loading-screen;
 
     let Kernel = #playground-kernel bootstrap: new kernel-config(
       session-id ->
@@ -45,7 +45,7 @@ do
 
     let Page = VM new-page: "Untitled";
     
-    agata show: new widget-playground-page(Page);
+    agata show: new screen-frame(vm -> VM, page -> Page);
   with
     use browser-kernel;
     use agata-dom-renderer root: Root;
@@ -54,6 +54,6 @@ do
 end
 
 command playground-app halt-with-error: (Error is playground-error) do
-  agata show: new welcome-error-screen(Error reason);
+  agata show: new loading-error-screen(Error reason);
   perform playground-app.halt();
 end

--- a/stdlib/crochet.debug.ui/source/playground/effects.crochet
+++ b/stdlib/crochet.debug.ui/source/playground/effects.crochet
@@ -16,6 +16,9 @@ effect playground with
     language is playground-language,
     code is text
   ); // -> result<any, playground-run-error>
+
+  // Returns the introductory documentation for the project
+  get-readme(vm is playground-vm); // -> untrusted-text
 end
 
 // FIXME: this creates a placeholder type
@@ -87,5 +90,10 @@ handler browser-kernel with
       otherwise =>
         continue with #result error: new playground-run-error-arbitrary(Result.reason);
     end
+  end
+
+  on playground.get-readme(VM) do
+    let Readme = foreign kernel.readme(VM.vm-box);
+    continue with Readme;
   end
 end

--- a/stdlib/crochet.debug.ui/source/playground/effects.crochet
+++ b/stdlib/crochet.debug.ui/source/playground/effects.crochet
@@ -19,6 +19,9 @@ effect playground with
 
   // Returns the introductory documentation for the project
   get-readme(vm is playground-vm); // -> untrusted-text
+
+  // Updates the introductory documentation for the project
+  update-readme(vm is playground-vm, code is text); // -> nothing
 end
 
 // FIXME: this creates a placeholder type
@@ -96,4 +99,13 @@ handler browser-kernel with
     let Readme = foreign kernel.readme(VM.vm-box);
     continue with Readme;
   end
+
+  on playground.update-readme(VM, Code) do
+    let Result = foreign kernel.update-root-readme(VM.vm-box, Code);
+    transcript tag: "error" inspect: Result;
+    assert Result.ok;
+    continue with nothing;
+  end
 end
+
+open crochet.debug;

--- a/stdlib/crochet.debug.ui/source/playground/vm.crochet
+++ b/stdlib/crochet.debug.ui/source/playground/vm.crochet
@@ -12,3 +12,6 @@ command playground-vm new-page: (Title is text) =
 
 command playground-vm readme =
   perform playground.get-readme(self);
+
+command playground-vm update-readme: (Code is text) =
+  perform playground.update-readme(self, Code);

--- a/stdlib/crochet.debug.ui/source/playground/vm.crochet
+++ b/stdlib/crochet.debug.ui/source/playground/vm.crochet
@@ -9,3 +9,6 @@ type playground-vm(
 
 command playground-vm new-page: (Title is text) =
   perform playground.new-page(self, Title);
+
+command playground-vm readme =
+  perform playground.get-readme(self);

--- a/stdlib/crochet.debug.ui/source/ui/frame.crochet
+++ b/stdlib/crochet.debug.ui/source/ui/frame.crochet
@@ -1,0 +1,26 @@
+% crochet
+
+open crochet.ui.agata;
+open crochet.concurrency;
+
+type screen-frame(
+  vm is playground-vm,
+  page is playground-page
+);
+
+implement to-widget for screen-frame;
+command screen-frame as widget do
+  let Selected = #observable-cell with-value: "welcome";
+
+  #widget tabbed-panel: [
+    #tab id: "welcome"
+      | header: "Welcome"
+      | content: new welcome-panel(self.vm),
+
+    #tab id: "playground"
+      | header: "Playground"
+      | content: new playground-panel(self.page),
+  ]
+  | selected: Selected
+  | fill-screen-vertically;
+end

--- a/stdlib/crochet.debug.ui/source/ui/loading.crochet
+++ b/stdlib/crochet.debug.ui/source/ui/loading.crochet
@@ -1,0 +1,35 @@
+% crochet
+
+open crochet.ui.agata;
+open crochet.concurrency;
+
+type loading-screen;
+
+implement to-widget for loading-screen;
+command loading-screen as widget do
+  #widget flex-column: [
+    #widget text: "Loading..."
+  ]
+  | align-items: #flex-align center
+  | justify-content: #flex-justify center;
+end
+
+
+type loading-error-screen(error is text);
+
+implement to-widget for loading-error-screen;
+command loading-error-screen as widget do
+  #widget flex-column: [
+    #widget section: [
+      #widget title: "Cannot initialise playground",
+      #widget text: self.error
+        | with-font: agata-theme-fonts monospace
+        | with-text-color: agata-theme-colors red
+        | with-white-space: #white-space pre-formatted-wrap-line
+    ]
+    | with-size: { S in S max-width: (80 as rem) }
+    | with-padding: { P in P all: (1 as rem) }
+  ]
+  | align-items: #flex-align center
+  | justify-content: #flex-justify center;
+end

--- a/stdlib/crochet.debug.ui/source/ui/playground-page.crochet
+++ b/stdlib/crochet.debug.ui/source/ui/playground-page.crochet
@@ -43,7 +43,7 @@ command widget-playground-page as widget do
   | with-box-overflow: { O in O style: #overflow-style auto
                                 | scroll-behavior: #scroll-behavior smooth
                                 | scroll-pin: #scroll-pin at-end }
-  | fill-screen-vertically;
+  | fill-container-vertically;
 end
 
 command widget-playground-page run-code: Code entries: New-entries error: Error do

--- a/stdlib/crochet.debug.ui/source/ui/playground-page.crochet
+++ b/stdlib/crochet.debug.ui/source/ui/playground-page.crochet
@@ -13,6 +13,7 @@ command widget-playground-page as widget do
   let New-entries = #event-stream empty;
   let Error = #observable-cell with-value: nothing;
   let Code = #observable-cell with-value: "";
+  let Editor = #reference with-name: "snippet-editor";
 
   #widget container: [
     self.page.entries value map: (self render-entry: _),
@@ -30,8 +31,16 @@ command widget-playground-page as widget do
           | auto-resize: true
           | value: Code
           | key-map: (#map from: [
-              "Ctrl-Enter" -> { _ in self run-code: Code entries: New-entries error: Error }
+              "Ctrl-Enter" -> { _ in 
+                let Value = Editor materialise value;
+                let Result = self run-code: Value entries: New-entries error: Error;
+                condition
+                  when Result is ok => Code <- "";
+                  otherwise => nothing;
+                end
+              }
             ])
+          | with-reference: Editor
       ),
       #card-child extra: (Error map: (self render-error: _))
     ]
@@ -46,12 +55,10 @@ command widget-playground-page as widget do
   | fill-container-vertically;
 end
 
-command widget-playground-page run-code: Code entries: New-entries error: Error do
-  let To-eval = Code value;
+command widget-playground-page run-code: To-eval entries: New-entries error: Error do
   let Result = self.page execute: #playground-language crochet code: To-eval;
   condition
     when Result is ok do
-      Code <- "";
       Error <- nothing;
       let Entry = new playground-entry-code(
         #playground-language crochet,
@@ -65,6 +72,7 @@ command widget-playground-page run-code: Code entries: New-entries error: Error 
       Error <- Result reason;
     end
   end
+  Result;
 end
 
 command widget-playground-page render-error: nothing =

--- a/stdlib/crochet.debug.ui/source/ui/playground.crochet
+++ b/stdlib/crochet.debug.ui/source/ui/playground.crochet
@@ -1,0 +1,9 @@
+% crochet
+
+open crochet.ui.agata;
+
+type playground-panel(page is playground-page);
+
+implement to-widget for playground-panel;
+command playground-panel as widget =
+  (new widget-playground-page(self.page)) as widget;

--- a/stdlib/crochet.debug.ui/source/ui/welcome.crochet
+++ b/stdlib/crochet.debug.ui/source/ui/welcome.crochet
@@ -1,16 +1,57 @@
 % crochet
 
 open crochet.ui.agata;
+open crochet.concurrency;
 
 type welcome-panel(vm is playground-vm);
+local type ctx(mode is observable-cell<welcome-panel-mode>, text is observable-cell<text>);
+
+local enum mode = view, edit;
 
 implement to-widget for welcome-panel;
 command welcome-panel as widget do
+  let Mode = #observable-cell with-value: #mode view;
+  let Readme = #observable-cell with-value: self.vm readme;
+  let Ctx = new ctx(mode -> Mode, text -> Readme);
+
   #widget container: [
-    #widget text: self.vm readme
+    #widget given: Mode
+      | when: (_ === #mode view) use: (self render-view: Ctx)
+      | when: (_ === #mode edit) use: (self render-edit: Ctx)
   ]
   | with-padding: { P in P all: (2 as rem) }
   | with-font: agata-theme-fonts monospace
   | with-box-overflow: #overflow-style auto
+  | fill-container-vertically
+end
+
+command welcome-panel render-view: Ctx do
+  #widget flex-column: [
+    #widget flex-row-reverse: [
+      #widget icon-button: "pen"
+        | on-click: { _ in Ctx.mode <- #mode edit }
+    ],
+
+    Ctx.text
+  ]
+end
+
+command welcome-panel render-edit: Ctx do
+  let Code = #observable-cell with-value: Ctx.text value;
+
+  #widget flex-column: [
+    #widget flex-row-reverse: [
+      #widget icon-button: "check"
+        | on-click: { _ in
+            Ctx.text <- Code value;
+            Ctx.mode <- #mode view;
+          }
+    ],
+
+    #flex-child fluid: (
+      #widget code-editor
+        | value: Code
+    )
+  ]
   | fill-container-vertically
 end

--- a/stdlib/crochet.debug.ui/source/ui/welcome.crochet
+++ b/stdlib/crochet.debug.ui/source/ui/welcome.crochet
@@ -43,6 +43,7 @@ command welcome-panel render-edit: Ctx do
     #widget flex-row-reverse: [
       #widget icon-button: "check"
         | on-click: { _ in
+            self.vm update-readme: Code value;
             Ctx.text <- Code value;
             Ctx.mode <- #mode view;
           }

--- a/stdlib/crochet.debug.ui/source/ui/welcome.crochet
+++ b/stdlib/crochet.debug.ui/source/ui/welcome.crochet
@@ -37,21 +37,24 @@ command welcome-panel render-view: Ctx do
 end
 
 command welcome-panel render-edit: Ctx do
-  let Code = #observable-cell with-value: Ctx.text value;
+  let Editor = #reference with-name: "readme-editor";
 
   #widget flex-column: [
     #widget flex-row-reverse: [
       #widget icon-button: "check"
         | on-click: { _ in
-            self.vm update-readme: Code value;
-            Ctx.text <- Code value;
+            let Code = Editor materialise value;
+            self.vm update-readme: Code;
+            Ctx.text <- Code;
             Ctx.mode <- #mode view;
           }
     ],
 
     #flex-child fluid: (
       #widget code-editor
-        | value: Code
+        | mode: "plain-text"
+        | value: Ctx.text
+        | with-reference: Editor
     )
   ]
   | fill-container-vertically

--- a/stdlib/crochet.debug.ui/source/ui/welcome.crochet
+++ b/stdlib/crochet.debug.ui/source/ui/welcome.crochet
@@ -1,35 +1,16 @@
 % crochet
 
 open crochet.ui.agata;
-open crochet.concurrency;
 
-type welcome-screen;
+type welcome-panel(vm is playground-vm);
 
-implement to-widget for welcome-screen;
-command welcome-screen as widget do
-  #widget flex-column: [
-    #widget text: "Loading..."
+implement to-widget for welcome-panel;
+command welcome-panel as widget do
+  #widget container: [
+    #widget text: self.vm readme
   ]
-  | align-items: #flex-align center
-  | justify-content: #flex-justify center;
-end
-
-
-type welcome-error-screen(error is text);
-
-implement to-widget for welcome-error-screen;
-command welcome-error-screen as widget do
-  #widget flex-column: [
-    #widget section: [
-      #widget title: "Cannot initialise playground",
-      #widget text: self.error
-        | with-font: agata-theme-fonts monospace
-        | with-text-color: agata-theme-colors red
-        | with-white-space: #white-space pre-formatted-wrap-line
-    ]
-    | with-size: { S in S max-width: (80 as rem) }
-    | with-padding: { P in P all: (1 as rem) }
-  ]
-  | align-items: #flex-align center
-  | justify-content: #flex-justify center;
+  | with-padding: { P in P all: (2 as rem) }
+  | with-font: agata-theme-fonts monospace
+  | with-box-overflow: #overflow-style auto
+  | fill-container-vertically
 end

--- a/stdlib/crochet.ui.agata/native/code-mirror.ts
+++ b/stdlib/crochet.ui.agata/native/code-mirror.ts
@@ -69,4 +69,16 @@ export default (ffi: ForeignInterface) => {
     });
     return ffi.nothing;
   });
+
+  ffi.defun("code-mirror.value-from-node", (node) => {
+    const el = ffi.unbox_typed(HTMLElement, node);
+    if (el.children.length !== 1) {
+      throw ffi.panic("invalid-node", `Expected a code-editor widget node`);
+    }
+    const cm: CM.Editor | null = (el.children[0] as any).CodeMirror;
+    if (cm == null) {
+      throw ffi.panic("invalid-node", `Expected a code-editor widget node`);
+    }
+    return ffi.text(cm.getDoc().getValue());
+  });
 };

--- a/stdlib/crochet.ui.agata/source/core/api.crochet
+++ b/stdlib/crochet.ui.agata/source/core/api.crochet
@@ -46,6 +46,3 @@ command agata navigate: (Page has agata-page) bindings: (Bindings is record) =
 command agata navigate: (Page has agata-page) =
   self navigate: Page bindings: [->];
 
-command agata reference: (Name is static-text) do
-  new reference(Name);
-end

--- a/stdlib/crochet.ui.agata/source/core/reference.crochet
+++ b/stdlib/crochet.ui.agata/source/core/reference.crochet
@@ -5,6 +5,9 @@ open crochet.concurrency;
 type reference(name is text);
 type reference-observer(reference is reference, observer is observable-cell<widget>);
 
+command #reference with-name: (Name is static-text) =
+  new reference(Name);
+
 command reference materialise =
   perform agata-presentation.get-reference(self);
 

--- a/stdlib/crochet.ui.agata/source/dom/live.crochet
+++ b/stdlib/crochet.ui.agata/source/dom/live.crochet
@@ -2,6 +2,7 @@
 
 type dom-element(node is dom-node) is live-widget;
 type dom-text-input(node is dom-node) is live-widget;
+type dom-code-editor(node is dom-node) is live-widget;
 
 command dom to-live-widget: (W is widget) node: (N is dom-node) =
   new dom-element(N);
@@ -9,8 +10,13 @@ command dom to-live-widget: (W is widget) node: (N is dom-node) =
 command dom to-live-widget: (W is widget-text-input) node: (N is dom-node) =
   new dom-text-input(N);
 
+command dom to-live-widget: (W is widget-code-editor) node: (N is dom-node) =
+  new dom-code-editor(N);
+
 
 command dom-text-input value =
   self.node text-input-value;
 
 
+command dom-code-editor value =
+  foreign code-mirror.value-from-node(self.node.box);

--- a/stdlib/crochet.ui.agata/source/dom/renderer/code.crochet
+++ b/stdlib/crochet.ui.agata/source/dom/renderer/code.crochet
@@ -34,7 +34,6 @@ end
 command dom-renderer render: (W is widget-code-editor) do
   let Surface = dom make-surface;
   let Node = Surface.node;
-  let Skip = #cell with-value: nothing;
 
   Node add-class: "agata-code-editor";
 
@@ -57,23 +56,11 @@ command dom-renderer render: (W is widget-code-editor) do
                 }
     ];
 
-  Code-mirror on: "changes" do: { _ in
-    let Value = Code-mirror value;
-    Skip <- Value;
-    W.value <- Value;
-  };
-
   W.mode stream subscribe: (Code-mirror set: "mode" to: _);
   W.read-only stream subscribe: (Code-mirror set: "readOnly" to: _);
   W.line-numbers stream subscribe: (Code-mirror set: "lineNumbers" to: _);
   W.line-wrapping stream subscribe: (Code-mirror set: "lineWrapping" to: _);
-  W.value stream subscribe: { M in
-    condition
-      when M =:= Skip value => nothing;
-      otherwise => Code-mirror set-value: M;
-    end
-    Skip <- nothing;
-  };
+  W.value stream subscribe: (Code-mirror set-value: _);
 
   Surface on-attached: {
     Code-mirror refresh;

--- a/stdlib/crochet.ui.agata/source/widget/layout/flex.crochet
+++ b/stdlib/crochet.ui.agata/source/widget/layout/flex.crochet
@@ -65,11 +65,19 @@ command internal to-flex-child: (Child has to-widget) =
 
 command #widget flex-column: (Children is list) =
   #widget flex: Children
-    | layout: "column";
+    | layout: #flex-layout column;
 
 command #widget flex-row: (Children is list) =
   #widget flex: Children
-    | layout: "row";
+    | layout: #flex-layout row;
+
+command #widget flex-row-reverse: (Children is list) =
+  #widget flex: Children
+    | layout: #flex-layout row-reverse;
+
+command #widget flex-column-reverse: (Children is list) =
+  #widget flex: Children
+    | layout: #flex-layout column-reverse;
 
 command #flex-child with: (Content has to-widget) =
   new flex-child(Content as widget, #flex-child-options defaults);

--- a/tools/lingua.js
+++ b/tools/lingua.js
@@ -178,7 +178,7 @@ const visitor = {
     TypeVariant_alt0: (meta_2, n_2, _1, p_2, _3_2) => (new _Ast_js__WEBPACK_IMPORTED_MODULE_3__.Variant(0, n_2, p_2)),
     TypeField_alt0: (meta_3, n_3, _1_1, t) => (new _Ast_js__WEBPACK_IMPORTED_MODULE_3__.Field(0, n_3, t)),
     TypeApp_alt0: (meta_4, t_1, _1_2) => (new _Ast_js__WEBPACK_IMPORTED_MODULE_3__.TypeApp(3, t_1)),
-    TypeApp_alt1: (meta_5, t_2, _1_3) => (new _Ast_js__WEBPACK_IMPORTED_MODULE_3__.TypeApp(4, t_2)),
+    TypeApp1_alt0: (meta_5, t_2, _1_3) => (new _Ast_js__WEBPACK_IMPORTED_MODULE_3__.TypeApp(4, t_2)),
     TypeApp2_alt0: (meta_6, t_3, _1_4, ps, _3_3) => (new _Ast_js__WEBPACK_IMPORTED_MODULE_3__.TypeApp(1, t_3, ps)),
     TypeApp3_alt0: (meta_7, t_4, _1_5, n_4) => (new _Ast_js__WEBPACK_IMPORTED_MODULE_3__.TypeApp(2, t_4, n_4)),
     TypeApp4_alt0: (meta_8, n_5) => (new _Ast_js__WEBPACK_IMPORTED_MODULE_3__.TypeApp(0, n_5)),
@@ -222,7 +222,7 @@ const visitor = {
     oneCharTerminal_alt0: (meta_46, t_20) => parseString(t_20),
 };
 
-const primParser = (0,_source_generated_fohm_runtime_js__WEBPACK_IMPORTED_MODULE_4__.makeParser)("\n    Linguist {\n      TypeDecl =\n        | type_ Name Formals \"(\" ListOf\u003cTypeField, \",\"\u003e \")\" -- alt0\n        | type_ Name Formals \"=\" \"|\"? NonemptyListOf\u003cTypeVariant, \"|\"\u003e -- alt1\n              \n      \n      TypeVariant =\n        | Name \"(\" ListOf\u003cTypeField, \",\"\u003e \")\" -- alt0\n              \n      \n      TypeField =\n        | Name \":\" TypeApp -- alt0\n              \n      \n      TypeApp =\n        | TypeApp2 \"[]\" -- alt0\n        | TypeApp2 \"?\" -- alt1\n        | TypeApp2 -- alt2\n              \n      \n      TypeApp2 =\n        | TypeApp3 \"\u003c\" NonemptyListOf\u003cTypeApp, \",\"\u003e \"\u003e\" -- alt0\n        | TypeApp3 -- alt1\n              \n      \n      TypeApp3 =\n        | TypeApp3 \".\" Name -- alt0\n        | TypeApp4 -- alt1\n              \n      \n      TypeApp4 =\n        | Name -- alt0\n        | \"(\" TypeApp \")\" -- alt1\n              \n      \n      Grammar =\n        | TypeDecl* grammar_ Name \":\" TypeApp \"{\" Rule* \"}\" -- alt0\n              \n      \n      Rule =\n        | token_ Rule -- alt0\n        | ident Formals ruleDescr? \"=\" RuleBody -- alt1\n        | ident Formals \":=\" RuleBody -- alt2\n        | ident Formals? \"+=\" RuleBody -- alt3\n              \n      \n      RuleBody =\n        | \"|\"? NonemptyListOf\u003cTopLevelTerm, \"|\"\u003e -- alt0\n              \n      \n      TopLevelTerm =\n        | Binder* \"-\u003e\" Action -- alt0\n        | Binder* -- alt1\n              \n      \n      Binder =\n        | Name \":\" Iter -- alt0\n        | Iter -- alt1\n              \n      \n      Action =\n        | ActionProject \"(\" ListOf\u003cAction, \",\"\u003e \")\" -- alt0\n        | ActionProject -- alt1\n              \n      \n      ActionProject =\n        | ActionProject \".\" Name -- alt0\n        | ActionPrimary -- alt1\n              \n      \n      ActionPrimary =\n        | meta_ -- alt0\n        | Name -- alt1\n        | null_ -- alt2\n        | ActionList -- alt3\n        | \"(\" Action \")\" -- alt4\n              \n      \n      ActionList =\n        | \"[\" NonemptyListOf\u003cAction, \",\"\u003e \",\" \"...\" Action \"]\" -- alt0\n        | \"[\" ListOf\u003cAction, \",\"\u003e \"]\" -- alt1\n              \n      \n      Formals =\n        | \"\u003c\" ListOf\u003cident, \",\"\u003e \"\u003e\" -- alt0\n        |  -- alt1\n              \n      \n      Params =\n        | \"\u003c\" ListOf\u003cSeq, \",\"\u003e \"\u003e\" -- alt0\n        |  -- alt1\n              \n      \n      Alt =\n        | NonemptyListOf\u003cSeq, \"|\"\u003e -- alt0\n              \n      \n      Seq =\n        | Iter* -- alt0\n              \n      \n      Iter =\n        | Pred \"*\" -- alt0\n        | Pred \"+\" -- alt1\n        | Pred \"?\" -- alt2\n        | Pred -- alt3\n              \n      \n      Pred =\n        | \"~\" Lex -- alt0\n        | \"\u0026\" Lex -- alt1\n        | Lex -- alt2\n              \n      \n      Lex =\n        | \"#\" Base -- alt0\n        | Base -- alt1\n              \n      \n      Base =\n        | ~reserved ident Params ~(ruleDescr? \"=\" | \":=\" | \"+=\") -- alt0\n        | oneCharTerminal \"..\" oneCharTerminal -- alt1\n        | terminal -- alt2\n        | \"(\" Alt \")\" -- alt3\n              \n      \n      ruleDescr (a,r,u,l,e,d,e,s,c,r,i,p,t,i,o,n) =\n        | \"(\" ruleDescrText \")\" -- alt0\n              \n      \n      ruleDescrText =\n        | (~\")\" any)* -- alt0\n              \n      \n      name (a,n,a,m,e) =\n        | nameFirst nameRest* -- alt0\n              \n      \n      nameFirst =\n        | \"_\" -- alt0\n        | letter -- alt1\n              \n      \n      nameRest =\n        | \"_\" -- alt0\n        | alnum -- alt1\n              \n      \n      ident (a,n,i,d,e,n,t,i,f,i,e,r) =\n        | name -- alt0\n              \n      \n      terminal =\n        | t_terminal -- alt0\n              \n      \n      t_terminal =\n        | \"\\\"\" terminalChar* \"\\\"\" -- alt0\n              \n      \n      oneCharTerminal =\n        | t_oneCharTerminal -- alt0\n              \n      \n      t_oneCharTerminal =\n        | \"\\\"\" terminalChar \"\\\"\" -- alt0\n              \n      \n      terminalChar =\n        | escapeChar -- alt0\n        | ~\"\\\\\" ~\"\\\"\" ~\"\\n\" any -- alt1\n              \n      \n      escapeChar (a,n,e,s,c,a,p,e,s,e,q,u,e,n,c,e) =\n        | \"\\\\\\\\\" -- alt0\n        | \"\\\\\\\"\" -- alt1\n        | \"\\\\b\" -- alt2\n        | \"\\\\n\" -- alt3\n        | \"\\\\r\" -- alt4\n        | \"\\\\t\" -- alt5\n        | \"\\\\u\" hexDigit hexDigit hexDigit hexDigit -- alt6\n        | \"\\\\x\" hexDigit hexDigit -- alt7\n              \n      \n      space +=\n        | comment -- alt0\n              \n      \n      comment =\n        | \"//\" (~\"\\n\" any)* \"\\n\" -- alt0\n        | \"/*\" (~\"*/\" any)* \"*/\" -- alt1\n              \n      \n      tokens =\n        | token* -- alt0\n              \n      \n      token =\n        | comment -- alt0\n        | ident -- alt1\n        | operator -- alt2\n        | punctuation -- alt3\n        | terminal -- alt4\n        | any -- alt5\n              \n      \n      operator =\n        | \"\u003c:\" -- alt0\n        | \"=\" -- alt1\n        | \":=\" -- alt2\n        | \"+=\" -- alt3\n        | \"*\" -- alt4\n        | \"+\" -- alt5\n        | \"?\" -- alt6\n        | \"~\" -- alt7\n        | \"\u0026\" -- alt8\n              \n      \n      punctuation =\n        | \"\u003c\" -- alt0\n        | \"\u003e\" -- alt1\n        | \",\" -- alt2\n        | \"--\" -- alt3\n              \n      \n      kw\u003ck\u003e =\n        | k ~nameRest -- alt0\n              \n      \n      type_ =\n        | kw\u003c\"type\"\u003e -- alt0\n              \n      \n      grammar_ =\n        | kw\u003c\"grammar\"\u003e -- alt0\n              \n      \n      meta_ =\n        | kw\u003c\"meta\"\u003e -- alt0\n              \n      \n      null_ =\n        | kw\u003c\"null\"\u003e -- alt0\n              \n      \n      token_ =\n        | kw\u003c\"token\"\u003e -- alt0\n              \n      \n      reserved =\n        | type_ -- alt0\n        | grammar_ -- alt1\n        | meta_ -- alt2\n        | null_ -- alt3\n        | token_ -- alt4\n              \n      \n      Name =\n        | ~reserved name -- alt0\n              \n    }\n      \n    ", visitor);
+const primParser = (0,_source_generated_fohm_runtime_js__WEBPACK_IMPORTED_MODULE_4__.makeParser)("\n    Lingua {\n      TypeDecl =\n        | type_ Name Formals \"(\" ListOf\u003cTypeField, \",\"\u003e \")\" -- alt0\n        | type_ Name Formals \"=\" \"|\"? NonemptyListOf\u003cTypeVariant, \"|\"\u003e -- alt1\n              \n      \n      TypeVariant =\n        | Name \"(\" ListOf\u003cTypeField, \",\"\u003e \")\" -- alt0\n              \n      \n      TypeField =\n        | Name \":\" TypeApp -- alt0\n              \n      \n      TypeApp =\n        | TypeApp \"[]\" -- alt0\n        | TypeApp1 -- alt1\n              \n      \n      TypeApp1 =\n        | TypeApp2 \"?\" -- alt0\n        | TypeApp2 -- alt1\n              \n      \n      TypeApp2 =\n        | TypeApp3 \"\u003c\" NonemptyListOf\u003cTypeApp, \",\"\u003e \"\u003e\" -- alt0\n        | TypeApp3 -- alt1\n              \n      \n      TypeApp3 =\n        | TypeApp3 \".\" Name -- alt0\n        | TypeApp4 -- alt1\n              \n      \n      TypeApp4 =\n        | Name -- alt0\n        | \"(\" TypeApp \")\" -- alt1\n              \n      \n      Grammar =\n        | TypeDecl* grammar_ Name \":\" TypeApp \"{\" Rule* \"}\" -- alt0\n              \n      \n      Rule =\n        | token_ Rule -- alt0\n        | ident Formals ruleDescr? \"=\" RuleBody -- alt1\n        | ident Formals \":=\" RuleBody -- alt2\n        | ident Formals? \"+=\" RuleBody -- alt3\n              \n      \n      RuleBody =\n        | \"|\"? NonemptyListOf\u003cTopLevelTerm, \"|\"\u003e -- alt0\n              \n      \n      TopLevelTerm =\n        | Binder* \"-\u003e\" Action -- alt0\n        | Binder* -- alt1\n              \n      \n      Binder =\n        | Name \":\" Iter -- alt0\n        | Iter -- alt1\n              \n      \n      Action =\n        | ActionProject \"(\" ListOf\u003cAction, \",\"\u003e \")\" -- alt0\n        | ActionProject -- alt1\n              \n      \n      ActionProject =\n        | ActionProject \".\" Name -- alt0\n        | ActionPrimary -- alt1\n              \n      \n      ActionPrimary =\n        | meta_ -- alt0\n        | Name -- alt1\n        | null_ -- alt2\n        | ActionList -- alt3\n        | \"(\" Action \")\" -- alt4\n              \n      \n      ActionList =\n        | \"[\" NonemptyListOf\u003cAction, \",\"\u003e \",\" \"...\" Action \"]\" -- alt0\n        | \"[\" ListOf\u003cAction, \",\"\u003e \"]\" -- alt1\n              \n      \n      Formals =\n        | \"\u003c\" ListOf\u003cident, \",\"\u003e \"\u003e\" -- alt0\n        |  -- alt1\n              \n      \n      Params =\n        | \"\u003c\" ListOf\u003cSeq, \",\"\u003e \"\u003e\" -- alt0\n        |  -- alt1\n              \n      \n      Alt =\n        | NonemptyListOf\u003cSeq, \"|\"\u003e -- alt0\n              \n      \n      Seq =\n        | Iter* -- alt0\n              \n      \n      Iter =\n        | Pred \"*\" -- alt0\n        | Pred \"+\" -- alt1\n        | Pred \"?\" -- alt2\n        | Pred -- alt3\n              \n      \n      Pred =\n        | \"~\" Lex -- alt0\n        | \"\u0026\" Lex -- alt1\n        | Lex -- alt2\n              \n      \n      Lex =\n        | \"#\" Base -- alt0\n        | Base -- alt1\n              \n      \n      Base =\n        | ~reserved ident Params ~(ruleDescr? \"=\" | \":=\" | \"+=\") -- alt0\n        | oneCharTerminal \"..\" oneCharTerminal -- alt1\n        | terminal -- alt2\n        | \"(\" Alt \")\" -- alt3\n              \n      \n      ruleDescr (a,r,u,l,e,d,e,s,c,r,i,p,t,i,o,n) =\n        | \"(\" ruleDescrText \")\" -- alt0\n              \n      \n      ruleDescrText =\n        | (~\")\" any)* -- alt0\n              \n      \n      name (a,n,a,m,e) =\n        | nameFirst nameRest* -- alt0\n              \n      \n      nameFirst =\n        | \"_\" -- alt0\n        | letter -- alt1\n              \n      \n      nameRest =\n        | \"_\" -- alt0\n        | alnum -- alt1\n              \n      \n      ident (a,n,i,d,e,n,t,i,f,i,e,r) =\n        | name -- alt0\n              \n      \n      terminal =\n        | t_terminal -- alt0\n              \n      \n      t_terminal =\n        | \"\\\"\" terminalChar* \"\\\"\" -- alt0\n              \n      \n      oneCharTerminal =\n        | t_oneCharTerminal -- alt0\n              \n      \n      t_oneCharTerminal =\n        | \"\\\"\" terminalChar \"\\\"\" -- alt0\n              \n      \n      terminalChar =\n        | escapeChar -- alt0\n        | ~\"\\\\\" ~\"\\\"\" ~\"\\n\" any -- alt1\n              \n      \n      escapeChar (a,n,e,s,c,a,p,e,s,e,q,u,e,n,c,e) =\n        | \"\\\\\\\\\" -- alt0\n        | \"\\\\\\\"\" -- alt1\n        | \"\\\\b\" -- alt2\n        | \"\\\\n\" -- alt3\n        | \"\\\\r\" -- alt4\n        | \"\\\\t\" -- alt5\n        | \"\\\\u\" hexDigit hexDigit hexDigit hexDigit -- alt6\n        | \"\\\\x\" hexDigit hexDigit -- alt7\n              \n      \n      space +=\n        | comment -- alt0\n              \n      \n      comment =\n        | \"//\" (~\"\\n\" any)* \"\\n\" -- alt0\n        | \"/*\" (~\"*/\" any)* \"*/\" -- alt1\n              \n      \n      tokens =\n        | token* -- alt0\n              \n      \n      token =\n        | comment -- alt0\n        | ident -- alt1\n        | operator -- alt2\n        | punctuation -- alt3\n        | terminal -- alt4\n        | any -- alt5\n              \n      \n      operator =\n        | \"\u003c:\" -- alt0\n        | \"=\" -- alt1\n        | \":=\" -- alt2\n        | \"+=\" -- alt3\n        | \"*\" -- alt4\n        | \"+\" -- alt5\n        | \"?\" -- alt6\n        | \"~\" -- alt7\n        | \"\u0026\" -- alt8\n              \n      \n      punctuation =\n        | \"\u003c\" -- alt0\n        | \"\u003e\" -- alt1\n        | \",\" -- alt2\n        | \"--\" -- alt3\n              \n      \n      kw\u003ck\u003e =\n        | k ~nameRest -- alt0\n              \n      \n      type_ =\n        | kw\u003c\"type\"\u003e -- alt0\n              \n      \n      grammar_ =\n        | kw\u003c\"grammar\"\u003e -- alt0\n              \n      \n      meta_ =\n        | kw\u003c\"meta\"\u003e -- alt0\n              \n      \n      null_ =\n        | kw\u003c\"null\"\u003e -- alt0\n              \n      \n      token_ =\n        | kw\u003c\"token\"\u003e -- alt0\n              \n      \n      reserved =\n        | type_ -- alt0\n        | grammar_ -- alt1\n        | meta_ -- alt2\n        | null_ -- alt3\n        | token_ -- alt4\n              \n      \n      Name =\n        | ~reserved name -- alt0\n              \n    }\n      \n    ", visitor);
 
 function parse(rule, source, options) {
     const patternInput = primParser(source, rule, options);
@@ -12611,10 +12611,10 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(21);
 /* harmony import */ var _fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9);
 /* harmony import */ var _fable_fable_library_3_1_5_Array_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(24);
-/* harmony import */ var _fable_fable_library_3_1_5_Set_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(28);
-/* harmony import */ var _fable_fable_library_3_1_5_Util_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(7);
-/* harmony import */ var _fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(29);
-/* harmony import */ var _OhmCodegen_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(30);
+/* harmony import */ var _OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(28);
+/* harmony import */ var _fable_fable_library_3_1_5_Set_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(29);
+/* harmony import */ var _fable_fable_library_3_1_5_Util_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(7);
+/* harmony import */ var _fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(30);
 
 
 
@@ -12723,7 +12723,7 @@ function genTypePatterns(n, patTypes, vs) {
 }
 
 function genVariantTags(vs) {
-    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" | ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((_arg1) => (JSON.stringify(_arg1.fields[0])), vs));
+    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" | ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((_arg1) => (0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.toString)(_arg1.fields[0]), vs));
 }
 
 function genThisProjection(_arg2) {
@@ -12760,8 +12760,8 @@ function getVariantFullname(p, n) {
 
 function genInitAsserts(ps, fs) {
     let ps_1;
-    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)("; ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((ps_1 = (0,_fable_fable_library_3_1_5_Set_js__WEBPACK_IMPORTED_MODULE_3__.ofSeq)(ps, {
-        Compare: (x, y) => (0,_fable_fable_library_3_1_5_Util_js__WEBPACK_IMPORTED_MODULE_4__.comparePrimitives)(x, y),
+    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)("; ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((ps_1 = (0,_fable_fable_library_3_1_5_Set_js__WEBPACK_IMPORTED_MODULE_4__.ofSeq)(ps, {
+        Compare: (x, y) => (0,_fable_fable_library_3_1_5_Util_js__WEBPACK_IMPORTED_MODULE_5__.comparePrimitives)(x, y),
     }), (arg10$0040) => genInitAssert(ps_1, arg10$0040)), fs));
 }
 
@@ -12772,7 +12772,7 @@ function genInitAssert(ps, _arg5) {
 function genAssert(ps, x, t) {
     let pattern_matching_result;
     if (t.tag === 0) {
-        if ((0,_fable_fable_library_3_1_5_Set_js__WEBPACK_IMPORTED_MODULE_3__.contains)(t.fields[0], ps)) {
+        if ((0,_fable_fable_library_3_1_5_Set_js__WEBPACK_IMPORTED_MODULE_4__.contains)(t.fields[0], ps)) {
             pattern_matching_result = 0;
         }
         else {
@@ -12870,7 +12870,7 @@ function genVisitorBinder(n, b) {
     }
     switch (pattern_matching_result) {
         case 0: {
-            return (0,_fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_5__.empty)();
+            return (0,_fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_6__.empty)();
         }
         case 1: {
             let pattern_matching_result_1;
@@ -12887,14 +12887,14 @@ function genVisitorBinder(n, b) {
             }
             switch (pattern_matching_result_1) {
                 case 0: {
-                    return (0,_fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_5__.empty)();
+                    return (0,_fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_6__.empty)();
                 }
                 case 1: {
                     if (b.tag === 1) {
-                        return (0,_fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_5__.singleton)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("_%P(): Ohm.Node", [n])));
+                        return (0,_fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_6__.singleton)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("_%P(): Ohm.Node", [n])));
                     }
                     else {
-                        return (0,_fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_5__.singleton)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()$0: Ohm.Node", [b.fields[0]])));
+                        return (0,_fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_6__.singleton)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()$0: Ohm.Node", [b.fields[0]])));
                     }
                 }
             }
@@ -13018,8 +13018,8 @@ function generateAstVisitor(g) {
 const prelude = "\r\nconst inspect = Symbol.for(\u0027nodejs.util.inspect.custom\u0027);\r\n\r\ntype Result\u003cA\u003e =\r\n  { ok: true, value: A }\r\n| { ok: false, error: string };\r\n\r\nexport abstract class Node {}\r\n\r\nexport class Meta {\r\n  constructor(readonly interval: Ohm.Interval) {}\r\n\r\n  static has_instance(x: any) {\r\n    return x instanceof Meta;\r\n  }\r\n\r\n  get position() {\r\n    const { lineNum, colNum } = OhmUtil.getLineAndColumn(\r\n      (this.interval as any).sourceString,\r\n      this.interval.startIdx\r\n    );\r\n    return {\r\n      line: lineNum,\r\n      column: colNum,\r\n    };\r\n  }\r\n\r\n  get range() {\r\n    return {\r\n      start: this.interval.startIdx,\r\n      end: this.interval.endIdx,\r\n    };\r\n  }\r\n\r\n  get source_slice() {\r\n    return this.interval.contents;\r\n  }\r\n\r\n  get formatted_position_message() {\r\n    return this.interval.getLineAndColumnMessage();\r\n  }\r\n\r\n  [inspect]() {\r\n    return this.position;\r\n  }\r\n}\r\n\r\nfunction $meta(x: Ohm.Node): Meta {\r\n  return new Meta(x.source);\r\n}\r\n\r\ntype Typed =\r\n  ((_: any) =\u003e boolean)\r\n| { has_instance(x: any): boolean };\r\n\r\nfunction $check_type(f: Typed) {\r\n  return (x: any) =\u003e {\r\n    if (typeof (f as any).has_instance === \"function\") {\r\n      return (f as any).has_instance(x);\r\n    } else {\r\n      return (f as any)(x);\r\n    }\r\n  }\r\n}\r\n\r\nfunction $is_type(t: string) {\r\n  return (x: any) =\u003e {\r\n    return typeof x === t;\r\n  };\r\n}\r\n\r\nfunction $is_array(f: Typed) {\r\n  return (x: any) =\u003e {\r\n    return Array.isArray(x) \u0026\u0026 x.every($check_type(f));\r\n  };\r\n}\r\n\r\nfunction $is_maybe(f: Typed) {\r\n  return (x: any) =\u003e {\r\n    return x === null || $check_type(f)(x);\r\n  };\r\n}\r\n\r\nfunction $is_null(x: any) {\r\n  return x === null;\r\n}\r\n\r\nfunction $assert_type\u003cT\u003e(x: any, t: string, f: Typed): asserts x is T {\r\n  if (!$check_type(f)(x)) {\r\n    throw new TypeError(`Expected ${t}, but got ${$inspect(x)}`);\r\n  }\r\n}\r\n  ";
 
 function generate(g) {
-    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("\r\n  // This file is generated from Linguist\r\n  import * as Ohm from \"ohm-js\";\r\n  const OhmUtil = require(\"ohm-js/src/util\");\r\n  import { inspect as $inspect } from \"util\";\r\n\r\n  %P()\r\n\r\n  // == Type definitions ==============================================\r\n  %P()\r\n\r\n  // == Grammar definition ============================================\r\n  export const grammar = Ohm.grammar(%P())\r\n\r\n  // == Parsing =======================================================\r\n  export function parse(source: string, rule: string): Result\u003c%P()\u003e {\r\n    const result = grammar.match(source, rule);\r\n    if (result.failed()) {\r\n      return { ok: false, error: result.message as string };\r\n    } else {\r\n      const ast = toAst(result);\r\n      %P()\r\n      return { ok: true, value: ast };\r\n    }\r\n  }\r\n\r\n  export const semantics = grammar.createSemantics();\r\n  export const toAstVisitor = (%P());\r\n  semantics.addOperation(\"toAST()\", toAstVisitor);\r\n\r\n  export function toAst(result: Ohm.MatchResult) {\r\n    return semantics(result).toAST();\r\n  }\r\n  ", [prelude, generateTypes(g.Types), JSON.stringify((0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_6__.generateGrammar)(g)), topType(g), genAssert((0,_fable_fable_library_3_1_5_Set_js__WEBPACK_IMPORTED_MODULE_3__.empty)({
-        Compare: (x, y) => (0,_fable_fable_library_3_1_5_Util_js__WEBPACK_IMPORTED_MODULE_4__.comparePrimitives)(x, y),
+    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("\r\n  // This file is generated from Linguist\r\n  import * as Ohm from \"ohm-js\";\r\n  const OhmUtil = require(\"ohm-js/src/util\");\r\n  import { inspect as $inspect } from \"util\";\r\n\r\n  %P()\r\n\r\n  // == Type definitions ==============================================\r\n  %P()\r\n\r\n  // == Grammar definition ============================================\r\n  export const grammar = Ohm.grammar(%P())\r\n\r\n  // == Parsing =======================================================\r\n  export function parse(source: string, rule: string): Result\u003c%P()\u003e {\r\n    const result = grammar.match(source, rule);\r\n    if (result.failed()) {\r\n      return { ok: false, error: result.message as string };\r\n    } else {\r\n      const ast = toAst(result);\r\n      %P()\r\n      return { ok: true, value: ast };\r\n    }\r\n  }\r\n\r\n  export const semantics = grammar.createSemantics();\r\n  export const toAstVisitor = (%P());\r\n  semantics.addOperation(\"toAST()\", toAstVisitor);\r\n\r\n  export function toAst(result: Ohm.MatchResult) {\r\n    return semantics(result).toAST();\r\n  }\r\n  ", [prelude, generateTypes(g.Types), (0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.toString)((0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.generateGrammar)(g)), topType(g), genAssert((0,_fable_fable_library_3_1_5_Set_js__WEBPACK_IMPORTED_MODULE_4__.empty)({
+        Compare: (x, y) => (0,_fable_fable_library_3_1_5_Util_js__WEBPACK_IMPORTED_MODULE_5__.comparePrimitives)(x, y),
     }), "ast", g.Top), generateAstVisitor(g)]));
 }
 
@@ -17112,6 +17112,148 @@ function HashSet__Remove_2B595(this$, k) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "enumerate": () => (/* binding */ enumerate),
+/* harmony export */   "toString": () => (/* binding */ toString),
+/* harmony export */   "genDesc": () => (/* binding */ genDesc),
+/* harmony export */   "genRuleParams": () => (/* binding */ genRuleParams),
+/* harmony export */   "genTerm": () => (/* binding */ genTerm),
+/* harmony export */   "genBinder": () => (/* binding */ genBinder),
+/* harmony export */   "genBody": () => (/* binding */ genBody),
+/* harmony export */   "genBodies": () => (/* binding */ genBodies),
+/* harmony export */   "generateRule": () => (/* binding */ generateRule),
+/* harmony export */   "generateRules": () => (/* binding */ generateRules),
+/* harmony export */   "generateGrammar": () => (/* binding */ generateGrammar)
+/* harmony export */ });
+/* harmony import */ var _fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(21);
+/* harmony import */ var _fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9);
+/* harmony import */ var _fable_fable_library_3_1_5_Option_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(19);
+
+
+
+
+function enumerate(xs) {
+    return (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.zip)((0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.rangeNumber)(1, 1, (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.length)(xs)), xs);
+}
+
+function toString(s) {
+    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.replace)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.replace)(JSON.stringify(s), "[", "\\x5b"), "]", "\\x5d");
+}
+
+function genDesc(desc) {
+    if (desc == null) {
+        return "";
+    }
+    else {
+        return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("(%P())", [(0,_fable_fable_library_3_1_5_Option_js__WEBPACK_IMPORTED_MODULE_2__.value)(desc)]));
+    }
+}
+
+function genRuleParams(ps) {
+    if (ps.length === 0) {
+        return "";
+    }
+    else {
+        return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("\u003c%P()\u003e", [(0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(", ", ps)]));
+    }
+}
+
+function genTerm(t) {
+    switch (t.tag) {
+        case 1: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" | ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((t_2) => genTerm(t_2), t.fields[0]));
+        }
+        case 2: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()*", [genTerm(t.fields[0])]));
+        }
+        case 3: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()+", [genTerm(t.fields[0])]));
+        }
+        case 4: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()?", [genTerm(t.fields[0])]));
+        }
+        case 5: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("~%P()", [genTerm(t.fields[0])]));
+        }
+        case 6: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("\u0026%P()", [genTerm(t.fields[0])]));
+        }
+        case 7: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("#%P()", [genTerm(t.fields[0])]));
+        }
+        case 8: {
+            const t_9 = t.fields[0];
+            const ps = t.fields[1];
+            if (ps.length === 0) {
+                return t_9;
+            }
+            else {
+                return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()\u003c%P()\u003e", [t_9, (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(", ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((t_10) => genTerm(t_10), ps))]));
+            }
+        }
+        case 9: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()..%P()", [toString(t.fields[0]), toString(t.fields[1])]));
+        }
+        case 10: {
+            return toString(t.fields[0]);
+        }
+        case 11: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("(%P())", [genTerm(t.fields[0])]));
+        }
+        default: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((t_1) => genTerm(t_1), t.fields[0]));
+        }
+    }
+}
+
+function genBinder(b) {
+    if (b.tag === 1) {
+        return genTerm(b.fields[0]);
+    }
+    else {
+        return genTerm(b.fields[1]);
+    }
+}
+
+function genBody(n, b) {
+    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()  -- alt%P()\n", [(0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((b_1) => genBinder(b_1), b.Terms)), n]));
+}
+
+function genBodies(b) {
+    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" | ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((tupledArg) => genBody(tupledArg[0], tupledArg[1]), enumerate(b)));
+}
+
+function generateRule(rule) {
+    switch (rule.tag) {
+        case 1: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()%P() := %P()", [rule.fields[1], genRuleParams(rule.fields[2]), genBodies(rule.fields[3])]));
+        }
+        case 2: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()%P() += %P()", [rule.fields[1], genRuleParams(rule.fields[2]), genBodies(rule.fields[3])]));
+        }
+        default: {
+            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()%P() %P() = %P()", [rule.fields[1], genRuleParams(rule.fields[2]), genDesc(rule.fields[3]), genBodies(rule.fields[4])]));
+        }
+    }
+}
+
+function generateRules(rules) {
+    return (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((rule) => generateRule(rule), rules);
+}
+
+function generateGrammar(g) {
+    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("\r\n  %P() {\r\n    %P()\r\n  }\r\n  ", [g.Name, (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)("\n\n", generateRules(g.Rules))]));
+}
+
+//# sourceMappingURL=OhmCodegen.js.map
+
+
+/***/ }),
+/* 29 */
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "SetTreeLeaf$1": () => (/* binding */ SetTreeLeaf$1),
 /* harmony export */   "SetTreeLeaf$1$reflection": () => (/* binding */ SetTreeLeaf$1$reflection),
 /* harmony export */   "SetTreeLeaf$1_$ctor_2B595": () => (/* binding */ SetTreeLeaf$1_$ctor_2B595),
@@ -19175,7 +19317,7 @@ function isProperSupersetOf(s1, s2, comparer) {
 
 
 /***/ }),
-/* 29 */
+/* 30 */
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 "use strict";
@@ -20464,143 +20606,6 @@ function transpose(lists) {
 
 
 /***/ }),
-/* 30 */
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "enumerate": () => (/* binding */ enumerate),
-/* harmony export */   "genDesc": () => (/* binding */ genDesc),
-/* harmony export */   "genRuleParams": () => (/* binding */ genRuleParams),
-/* harmony export */   "genTerm": () => (/* binding */ genTerm),
-/* harmony export */   "genBinder": () => (/* binding */ genBinder),
-/* harmony export */   "genBody": () => (/* binding */ genBody),
-/* harmony export */   "genBodies": () => (/* binding */ genBodies),
-/* harmony export */   "generateRule": () => (/* binding */ generateRule),
-/* harmony export */   "generateRules": () => (/* binding */ generateRules),
-/* harmony export */   "generateGrammar": () => (/* binding */ generateGrammar)
-/* harmony export */ });
-/* harmony import */ var _fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(21);
-/* harmony import */ var _fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9);
-/* harmony import */ var _fable_fable_library_3_1_5_Option_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(19);
-
-
-
-
-function enumerate(xs) {
-    return (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.zip)((0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.rangeNumber)(1, 1, (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.length)(xs)), xs);
-}
-
-function genDesc(desc) {
-    if (desc == null) {
-        return "";
-    }
-    else {
-        return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("(%P())", [(0,_fable_fable_library_3_1_5_Option_js__WEBPACK_IMPORTED_MODULE_2__.value)(desc)]));
-    }
-}
-
-function genRuleParams(ps) {
-    if (ps.length === 0) {
-        return "";
-    }
-    else {
-        return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("\u003c%P()\u003e", [(0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(", ", ps)]));
-    }
-}
-
-function genTerm(t) {
-    switch (t.tag) {
-        case 1: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" | ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((t_2) => genTerm(t_2), t.fields[0]));
-        }
-        case 2: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()*", [genTerm(t.fields[0])]));
-        }
-        case 3: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()+", [genTerm(t.fields[0])]));
-        }
-        case 4: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()?", [genTerm(t.fields[0])]));
-        }
-        case 5: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("~%P()", [genTerm(t.fields[0])]));
-        }
-        case 6: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("\u0026%P()", [genTerm(t.fields[0])]));
-        }
-        case 7: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("#%P()", [genTerm(t.fields[0])]));
-        }
-        case 8: {
-            const t_9 = t.fields[0];
-            const ps = t.fields[1];
-            if (ps.length === 0) {
-                return t_9;
-            }
-            else {
-                return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()\u003c%P()\u003e", [t_9, (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(", ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((t_10) => genTerm(t_10), ps))]));
-            }
-        }
-        case 9: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()..%P()", [JSON.stringify(t.fields[0]), JSON.stringify(t.fields[1])]));
-        }
-        case 10: {
-            return JSON.stringify(t.fields[0]);
-        }
-        case 11: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("(%P())", [genTerm(t.fields[0])]));
-        }
-        default: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((t_1) => genTerm(t_1), t.fields[0]));
-        }
-    }
-}
-
-function genBinder(b) {
-    if (b.tag === 1) {
-        return genTerm(b.fields[0]);
-    }
-    else {
-        return genTerm(b.fields[1]);
-    }
-}
-
-function genBody(n, b) {
-    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()  -- alt%P()\n", [(0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((b_1) => genBinder(b_1), b.Terms)), n]));
-}
-
-function genBodies(b) {
-    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)(" | ", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((tupledArg) => genBody(tupledArg[0], tupledArg[1]), enumerate(b)));
-}
-
-function generateRule(rule) {
-    switch (rule.tag) {
-        case 1: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()%P() := %P()", [rule.fields[1], genRuleParams(rule.fields[2]), genBodies(rule.fields[3])]));
-        }
-        case 2: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()%P() += %P()", [rule.fields[1], genRuleParams(rule.fields[2]), genBodies(rule.fields[3])]));
-        }
-        default: {
-            return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("%P()%P() %P() = %P()", [rule.fields[1], genRuleParams(rule.fields[2]), genDesc(rule.fields[3]), genBodies(rule.fields[4])]));
-        }
-    }
-}
-
-function generateRules(rules) {
-    return (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_0__.map)((rule) => generateRule(rule), rules);
-}
-
-function generateGrammar(g) {
-    return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.interpolate)("\r\n  %P() {\r\n    %P()\r\n  }\r\n  ", [g.Name, (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_1__.join)("\n\n", generateRules(g.Rules))]));
-}
-
-//# sourceMappingURL=OhmCodegen.js.map
-
-
-/***/ }),
 /* 31 */
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
@@ -20635,8 +20640,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ });
 /* harmony import */ var _fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9);
 /* harmony import */ var _fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(21);
-/* harmony import */ var _fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(29);
-/* harmony import */ var _OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(30);
+/* harmony import */ var _fable_fable_library_3_1_5_List_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(30);
+/* harmony import */ var _OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(28);
 /* harmony import */ var _fable_fable_library_3_1_5_Types_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6);
 /* harmony import */ var _fable_fable_library_3_1_5_Array_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(24);
 
@@ -20866,7 +20871,7 @@ function genVisitorEffect(n, expr) {
 }
 
 function genAltVisitor(tk, n, i, b) {
-    const name = JSON.stringify(((n + "_alt") + (0,_fable_fable_library_3_1_5_Types_js__WEBPACK_IMPORTED_MODULE_4__.toString)(i)));
+    const name = (0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.toString)((n + "_alt") + (0,_fable_fable_library_3_1_5_Types_js__WEBPACK_IMPORTED_MODULE_4__.toString)(i));
     if (tk) {
         return (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.interpolate)("  %P() -\u003e #lingua visitor-source,", [name]));
     }
@@ -20879,7 +20884,7 @@ function genAltVisitor(tk, n, i, b) {
 }
 
 function genRuleVisitor(tk, n, b) {
-    return ((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.interpolate)("  %P() -\u003e #lingua visitor-identity,", [JSON.stringify(n)])) + "\n") + (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.join)("\n", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_1__.map)((tupledArg) => genAltVisitor(tk, n, tupledArg[0], tupledArg[1]), (0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.enumerate)(b)));
+    return ((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.interpolate)("  %P() -\u003e #lingua visitor-identity,", [(0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.toString)(n)])) + "\n") + (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.join)("\n", (0,_fable_fable_library_3_1_5_Seq_js__WEBPACK_IMPORTED_MODULE_1__.map)((tupledArg) => genAltVisitor(tk, n, tupledArg[0], tupledArg[1]), (0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.enumerate)(b)));
 }
 
 function genVisitor(rule) {
@@ -20906,7 +20911,7 @@ function topRule(g) {
 }
 
 function generate(g) {
-    return "% crochet" + (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.interpolate)("\r\n// This file is generated from Lingua\r\n\r\nopen crochet.text.parsing.lingua;\r\n\r\n// Type definitions\r\nlocal abstract ast-node is node;\r\n%P()\r\n\r\nsingleton %P();\r\n\r\n// Grammar definition\r\nlocal define grammar =\r\n  lazy (#lingua grammar: %P());\r\n\r\nlocal define to-ast =\r\n  lazy ((force grammar) semantics: [\r\n    %P()\r\n  ]);\r\n\r\ncommand %P() grammar = force grammar;\r\n\r\ncommand %P() to-ast = force to-ast;\r\n\r\ncommand %P() parse: (Input is text) -\u003e result\u003c%P(), string\u003e do\r\n  let Tree = self grammar parse: Input rule: %P();\r\n  Tree map: { X in self to-ast transform: X };\r\nend\r\n  ", [generateTypes(g.Types), typeName(g.Name), JSON.stringify((0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.generateGrammar)(g)), generateVisitors(g), typeName(g.Name), typeName(g.Name), typeName(g.Name), genTypeApp(g.Top), topRule(g)]));
+    return "% crochet" + (0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.toText)((0,_fable_fable_library_3_1_5_String_js__WEBPACK_IMPORTED_MODULE_0__.interpolate)("\r\n// This file is generated from Lingua\r\n\r\nopen crochet.text.parsing.lingua;\r\n\r\n// Type definitions\r\nlocal abstract ast-node is node;\r\n%P()\r\n\r\nsingleton %P();\r\n\r\n// Grammar definition\r\nlocal define grammar =\r\n  lazy (#lingua grammar: %P());\r\n\r\nlocal define to-ast =\r\n  lazy ((force grammar) semantics: [\r\n    %P()\r\n  ]);\r\n\r\ncommand %P() grammar = force grammar;\r\n\r\ncommand %P() to-ast = force to-ast;\r\n\r\ncommand %P() parse: (Input is text) -\u003e result\u003c%P(), string\u003e do\r\n  let Tree = self grammar parse: Input rule: %P();\r\n  Tree map: { X in self to-ast transform: X };\r\nend\r\n  ", [generateTypes(g.Types), typeName(g.Name), (0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.toString)((0,_OhmCodegen_js__WEBPACK_IMPORTED_MODULE_3__.generateGrammar)(g)), generateVisitors(g), typeName(g.Name), typeName(g.Name), typeName(g.Name), genTypeApp(g.Top), topRule(g)]));
 }
 
 //# sourceMappingURL=CrochetCodegen.js.map

--- a/www/agata.css
+++ b/www/agata.css
@@ -478,6 +478,11 @@ textarea {
 }
 
 /* Tabbed panels */
+.agata-tabbed-panel-container {
+  display: flex;
+  flex-direction: column;
+}
+
 .agata-tabbed-panel-header-container {
   height: 48px;
   display: flex;
@@ -486,6 +491,8 @@ textarea {
   justify-content: flex-start;
   background: var(--white);
   border-bottom: 1px solid var(--blue-grey-10);
+  box-shadow: 0px 1px 1px rgb(0, 0, 0, 0.1);
+  flex-shrink: 0;
 }
 
 .agata-tabbed-panel-header {
@@ -502,6 +509,15 @@ textarea {
 
 .agata-tabbed-panel-header:hover {
   background: var(--blue-grey-10);
+}
+
+.agata-tabbed-panel-content-container {
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+.agata-tabbed-panel-content {
+  height: 100%;
 }
 
 .agata-tabbed-panel-content:not(.selected) {


### PR DESCRIPTION
This patch will allow the Playground to show a rendered README file to the user, though hyperlinks will not be resolved in this patch specifically as they need to work in conjunction with the Browser patch later. This will include a less ad-hoc version of the simplified/extensible Markdown language that is already in use throughout Crochet's doc-comments and in the `docs` tool.

- [x] Viewing README files in the playground
- [x] Editing README files *from* the playground
- ~Rendering README files with Crochet's Markdown dialect~ (to be handled in a separate PR)
- [x] Handle non-existing README files/files with different names